### PR TITLE
fix: make MediaExternalLink fields public

### DIFF
--- a/src/objects/media.rs
+++ b/src/objects/media.rs
@@ -141,11 +141,11 @@ pub struct MediaEdge {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MediaExternalLink {
-    id: i32,
-    url: Option<String>,
-    site: Option<String>,
-    site_id: Option<i32>,
-    link_type: Option<ExternalLinkType>,
+    pub id: i32,
+    pub url: Option<String>,
+    pub site: Option<String>,
+    pub site_id: Option<i32>,
+    pub link_type: Option<ExternalLinkType>,
     pub language: Option<String>,
     pub color: Option<String>,
     pub icon: Option<String>,


### PR DESCRIPTION
# Pull Request

## Description
Various fields were not set public which made them impossible to use as a consumer of the API.

Closes #3 

## Type of Change
- [x] Bug fix

## Testing
- [ ] Tests added/updated **no updates**
- [ ] All tests pass **Tests are flaky, can't determine. Probably rate limit?**
- [x] Manual testing completed

## Checklist
- [x] Code follows style guidelines
- [ ] Documentation updated **nothing to change**
- [x] No breaking changes (or documented)
- [ ] Tests pass locally **Tests are flaky, can't determine. Probably rate limit?**
