### PR TITLE
Dev

### DIFF
--- a/.husky/hooks/pre-commit
+++ b/.husky/hooks/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 echo "Running pre-commit hook"
-cargo fmt
+cargo fmt -- --check
 cargo clippy -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## Versioning
+
+This project uses [Semantic Versioning](https://semver.org/):
+- **MAJOR** version for incompatible API changes
+- **MINOR** version for new functionality in a backwards compatible manner
+- **PATCH** version for backwards compatible bug fixes
 
 ## [Unreleased]
 
@@ -11,7 +15,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-## [0.2.0] - 2024
+### Fixed
+
+### Breaking Changes
+
+## [0.3.0] - 2024-10-14
+
+### Added
+- **Husky Pre-commit Hooks**: Added husky-rs for automated code quality checks
+  - Runs `cargo fmt --check` before commits
+  - Runs `cargo clippy -- -D warnings` before commits
+  - Ensures consistent code style and catches common issues
+
+### Changed
+- **Response Format Simplification**: Major refactoring of response types for cleaner API
+  - Removed redundant wrapper types (`PageResponse`, `ViewerResponse`, etc.)
+  - Simplified response access patterns: `response.data` instead of nested wrappers
+  - All endpoints now use `GraphQLResponse<T>` and `Page<T>` directly
+  - Example: `GraphQLResponse<Page<Vec<Media>>>` instead of `GraphQLResponse<PageResponse<MediaData>>`
+- **Common Endpoint**: Simplified return types
+  - `toggle_like()` now returns `LikeableUnion` directly instead of `ToggleLikeResponse`
+  - `toggle_follow()` now returns `User` directly instead of `ToggleFollowResponse`
+  - `toggle_favourite()` now returns `Favourites` directly instead of `ToggleFavouriteResponse`
+- **Review Endpoint**: Simplified delete operation
+  - `delete()` now returns `bool` directly
+  - Uses `Deleted` struct internally for consistency
+- **User Endpoint**: Fixed authenticated user fetch
+  - `fetch_basic()` now returns `User` directly instead of `ViewerUserData`
+  - Simplified viewer query responses
+
+### Fixed
+- **MediaExternalLink**: Made all fields public for proper access (#4 by @Nachtalb, fixed #3)
+  - Fields `id`, `url`, `site`, `type`, `language`, `color`, `icon`, and `isDisabled` are now public
+- **ListActivity**: Made `status` field public for proper access
+- **MediaConnection**: Made `edges`, `nodes`, and `page_info` fields public
+- **MediaEdge**: Made `node`, `id`, and `relation_type` fields public
+- **ThreadComment**: Removed extra blank line for code consistency
+
+### Breaking Changes
+- Response structure changed from `response.data.page.data.media` to `response.data` for paginated endpoints
+- Response wrapper types removed - direct access to data types
+- All endpoints return simplified response types
+
+## [0.2.2] - 2024-10-13
+
+### Fixed
+- **Authenticated User Fetch**: Fixed issue with fetching current authenticated user
+- Added `color` and `main_studio` fields in media fetch operations
+
+## [0.2.1] - 2024-10-13
+
+### Fixed
+- **Critical Hotfix**: Fixed authenticated user fetch functionality
+  - Resolved issue where fetching the current authenticated user would fail
+  - Updated user query to properly handle viewer context
+
+## [0.2.0] - 2024-10
 
 ### Added
 - **Type Safety**: All endpoints now return properly typed responses instead of `serde_json::Value`
@@ -155,15 +214,10 @@ let response = client.anime().get_popular_anime(Some(1), Some(10)).await?;
 - GraphQL query execution
 - Basic pagination support
 - Async/await support with tokio
+- Added Support for Synonyms (#1 By @Random-Scientist)
+- Added Basic Support for Anime Relations (#2 By @Random-Scientist)
 
 ---
-
-## Versioning
-
-This project uses [Semantic Versioning](https://semver.org/):
-- **MAJOR** version for incompatible API changes
-- **MINOR** version for new functionality in a backwards compatible manner
-- **PATCH** version for backwards compatible bug fixes
 
 ## Links
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,8 @@ impl NewEndpoint {
     }
 
     /// Get items with options
-    pub async fn fetch(&self, options: FetchOptions) -> Result<ItemListResponse, AniListError> {
+    /// Returns Page<Vec<Item>>
+    pub async fn fetch(&self, options: FetchOptions) -> Result<Page<Vec<Item>>, AniListError> {
         let query = queries::new_endpoint::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
@@ -121,8 +122,9 @@ impl NewEndpoint {
     }
 
     /// Convenience function - get popular items
+    /// Returns Page<Vec<Item>>
     pub async fn get_popular(&self, page: Option<i32>, per_page: Option<i32>)
-        -> Result<ItemListResponse, AniListError> {
+        -> Result<Page<Vec<Item>>, AniListError> {
         self.fetch(FetchOptions {
             sort: Some(vec![Sort::Popularity]),
             page,
@@ -130,34 +132,43 @@ impl NewEndpoint {
             ..Default::default()
         }).await
     }
+
+    /// Get a single item by ID
+    /// Returns Item directly (not wrapped)
+    pub async fn get_by_id(&self, id: i32) -> Result<Item, AniListError> {
+        let query = queries::new_endpoint::FETCH_ONE;
+        let variables = json!({ "id": id });
+        let variables_map = crate::utils::json_to_hashmap(variables);
+        self.client.query_typed(query, Some(&variables_map)).await
+    }
 }
 ```
 
 ### Adding Response Types
 
-Add to `src/objects/responses.rs`:
+Response types are defined in `src/objects/responses.rs`:
 ```rust
-// Data wrapper
+/// GraphQL response wrapper
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphQLResponse<T> {
+    pub data: T,
+}
+
+/// Pagination wrapper for list responses
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ItemData {
-    pub items: Vec<Item>,
+pub struct Page<T> {
+    pub page_info: Option<PageInfo>,
+    pub data: T,
 }
-
-// Single item wrapper
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ItemResponse {
-    #[serde(rename = "Item")]
-    pub item: Item,
-}
-
-// Type aliases
-pub type ItemListResponse = GraphQLResponse<PageResponse<ItemData>>;
-pub type ItemSingleResponse = GraphQLResponse<ItemResponse>;
 ```
+
+Notes on response structure:
+- Paginated endpoints return `Page<Vec<T>>` - access the list through `response.data`
+- Single item endpoints return `T` directly - no extra wrapper
+- The `GraphQLResponse<T>` wrapper is handled internally by the client
+- All endpoint methods are already properly typed
 
 ### Writing Tests
 
@@ -170,7 +181,27 @@ async fn test_get_popular() {
 
     assert!(result.is_ok());
     let response = result.unwrap();
-    assert!(!response.data.page.data.items.is_empty());
+
+    // Response is Page<Vec<Item>>
+    // Access the Vec<Item> through response.data
+    assert!(!response.data.is_empty());
+
+    // Access pagination info
+    if let Some(page_info) = &response.page_info {
+        assert!(page_info.current_page.is_some());
+    }
+}
+
+#[tokio::test]
+async fn test_get_by_id() {
+    let client = get_test_client();
+    let result = client.new_endpoint().get_by_id(1).await;
+
+    assert!(result.is_ok());
+    let item = result.unwrap();
+
+    // Response is Item directly (not wrapped)
+    assert_eq!(item.id, Some(1));
 }
 ```
 
@@ -182,7 +213,7 @@ async fn test_get_popular() {
 4. Run all tests and ensure they pass:
    ```bash
    cargo test
-   cargo clippy
+   cargo clippy -- -D warning
    cargo fmt --check
    ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "anilist_moe"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anilist_moe"
-version = "0.2.1"
+version = "0.2.2"
 description = "Anilist_Moe is a Rust Wrapper for the Anilist API. This library allows you to seamlessly interact with Anilist's Public API with and without authentication. This currently supports Anime, Manga, Users, Staff, Forum, Threads, Recommendations, Reviews and User Activities"
 edition = "2024"
 license = "MIT"

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -19,14 +19,14 @@ Comprehensive examples for using the anilist_moe crate.
 ### Creating a Client
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 // Unauthenticated client for public data
 let client = AniListClient::new();
 
 // Authenticated client for user-specific operations
 let token = std::env::var("ANILIST_TOKEN").expect("Token required");
-let auth_client = AniListClient::with_token(token);
+let auth_client = AniListClient::with_token(&token);
 ```
 
 ## Anime Examples
@@ -34,15 +34,17 @@ let auth_client = AniListClient::with_token(token);
 ### Get Trending Anime
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
-    let response = client.anime().get_trending(Some(1), Some(10)).await?;
+    // Returns Page<Vec<Media>>
+    let response = client.anime().get_trending_anime(Some(1), Some(10)).await?;
 
-    for anime in &response.data.page.data.media {
+    // Access the Vec<Media> through response.data
+    for anime in &response.data {
         if let Some(title) = &anime.title {
             if let Some(romaji) = &title.romaji {
                 println!("Anime: {}", romaji);
@@ -59,18 +61,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Search Anime by Title
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
     let search_query = "Steins Gate";
-    let response = client.anime().search(search_query, Some(1), Some(10)).await?;
+    // Returns Page<Vec<Media>>
+    let response = client.anime().search_anime(search_query, Some(1), Some(10)).await?;
 
-    for anime in &response.data.page.data.media {
+    // Access pagination info
+    if let Some(page_info) = &response.page_info {
+        println!("Total results: {:?}", page_info.total);
+    }
+
+    // Iterate through media list
+    for anime in &response.data {
         if let Some(title) = &anime.title {
-            println!("Found: {} (ID: {})",
+            println!("Found: {} (ID: {:?})",
                 title.romaji.as_ref().unwrap_or(&"Unknown".to_string()),
                 anime.id
             );
@@ -84,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Get Anime by Season
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::{AniListClient, enums::media::MediaSeason};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -92,11 +101,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Get Fall 2024 anime
     let response = client.anime()
-        .get_by_season("FALL", 2024, Some(1), Some(20))
+        .get_by_season(MediaSeason::Fall, 2024, Some(1), Some(20))
         .await?;
 
     println!("Fall 2024 Anime:");
-    for anime in &response.data.page.data.media {
+    for anime in &response.data {
         if let Some(title) = &anime.title {
             println!("  - {}", title.romaji.as_ref().unwrap_or(&"Unknown".to_string()));
         }
@@ -109,15 +118,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Get Detailed Anime Information
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
     // Attack on Titan ID: 16498
-    let response = client.anime().get_by_id(16498).await?;
-    let anime = &response.data.media;
+    // Returns Media directly (not wrapped)
+    let anime = client.anime().get_by_id(16498).await?;
 
     println!("=== Anime Details ===");
 
@@ -148,16 +157,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Get Top Rated Manga
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
-    let response = client.manga().get_top_rated(Some(1), Some(10)).await?;
+    // Returns Page<Vec<Media>>
+    let response = client.manga().get_top_rated_manga(Some(1), Some(10)).await?;
 
     println!("Top Rated Manga:");
-    for (i, manga) in response.data.page.data.media.iter().enumerate() {
+    for (i, manga) in response.data.iter().enumerate() {
         if let Some(title) = &manga.title {
             println!("{}. {} - Score: {}/100",
                 i + 1,
@@ -174,16 +184,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Get Currently Releasing Manga
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
-    let response = client.manga().get_releasing(Some(1), Some(20)).await?;
+    // Returns Page<Vec<Media>>
+    let response = client.manga().get_releasing_manga(Some(1), Some(20)).await?;
 
     println!("Currently Releasing Manga:");
-    for manga in &response.data.page.data.media {
+    for manga in &response.data {
         if let Some(title) = &manga.title {
             println!("  - {}", title.romaji.as_ref().unwrap_or(&"Unknown".to_string()));
             if let Some(chapters) = manga.chapters {
@@ -201,18 +212,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Search for Characters
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
-    let response = client.character().search("Luffy", Some(1), Some(5)).await?;
+    // Returns Page<Vec<Character>>
+    let response = client.character().search_character("Luffy", Some(1), Some(5)).await?;
 
-    for character in &response.data.page.data.characters {
+    for character in &response.data {
         if let Some(name) = &character.name {
             println!("Character: {}", name.full.as_ref().unwrap_or(&"Unknown".to_string()));
-            println!("  ID: {}", character.id);
+            if let Some(id) = character.id {
+                println!("  ID: {}", id);
+            }
             if let Some(favourites) = character.favourites {
                 println!("  Favourites: {}", favourites);
             }
@@ -226,17 +240,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Get Characters by Birthday
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
     // Get characters with birthday on May 5th
+    // Returns Page<Vec<Character>>
     let response = client.character().get_by_birthday(5, 5, Some(1), Some(10)).await?;
 
     println!("Characters born on May 5th:");
-    for character in &response.data.page.data.characters {
+    for character in &response.data {
         if let Some(name) = &character.name {
             println!("  - {}", name.full.as_ref().unwrap_or(&"Unknown".to_string()));
         }
@@ -251,16 +266,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Get Popular Staff
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
-    let response = client.staff().get_popular(Some(1), Some(10)).await?;
+    // Returns Page<Vec<Staff>>
+    let response = client.staff().get_popular_staff(Some(1), Some(10)).await?;
 
     println!("Popular Staff:");
-    for staff in &response.data.page.data.staff {
+    for staff in &response.data {
         if let Some(name) = &staff.name {
             println!("  - {}", name.full.as_ref().unwrap_or(&"Unknown".to_string()));
             if let Some(favourites) = staff.favourites {
@@ -278,17 +294,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Get User Information
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
-    let response = client.user().get_by_username("username").await?;
-    let user = &response.data.user;
+    // Returns User directly (not wrapped)
+    let user = client.user().get_by_username("username").await?;
 
     println!("User: {}", user.name);
-    println!("ID: {}", user.id);
+    if let Some(id) = user.id {
+        println!("ID: {}", id);
+    }
 
     if let Some(about) = &user.about {
         println!("About: {}", about);
@@ -310,18 +328,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Get Current Authenticated User
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let token = std::env::var("ANILIST_TOKEN")?;
-    let client = AniListClient::with_token(token);
+    let client = AniListClient::with_token(&token);
 
-    let response = client.user().get_current_user().await?;
-    let user = &response.data.viewer;
+    // Returns User directly (not wrapped)
+    let user = client.user().get_current_user().await?;
 
     println!("Logged in as: {}", user.name);
-    println!("User ID: {}", user.id);
+    if let Some(id) = user.id {
+        println!("User ID: {}", id);
+    }
 
     if let Some(unread) = user.unread_notification_count {
         println!("Unread notifications: {}", unread);
@@ -336,20 +356,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Browse Forum Threads
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
-    // Get recent threads
-    let response = client.forum().get_recent(Some(1), Some(10)).await?;
+    // Get recent threads - Returns Page<Vec<Thread>>
+    let response = client.forum().get_recent_threads(Some(1), Some(10)).await?;
 
     println!("Recent Forum Threads:");
-    for thread in &response.data.page.data.threads {
+    for thread in &response.data {
         if let Some(title) = &thread.title {
             println!("\n  Title: {}", title);
-            println!("  ID: {}", thread.id);
+            if let Some(id) = thread.id {
+                println!("  ID: {}", id);
+            }
             println!("  Replies: {}", thread.reply_count.unwrap_or(0));
             println!("  Views: {}", thread.view_count.unwrap_or(0));
         }
@@ -362,16 +384,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Search Forum Threads
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
-    let response = client.forum().search("recommendation", Some(1), Some(10)).await?;
+    // Returns Page<Vec<Thread>>
+    let response = client.forum().search_thread("recommendation", Some(1), Some(10)).await?;
 
     println!("Search Results:");
-    for thread in &response.data.page.data.threads {
+    for thread in &response.data {
         if let Some(title) = &thread.title {
             println!("  - {}", title);
         }
@@ -384,17 +407,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Get Thread Comments
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
     let thread_id = 12345;
+    // Returns Page<Vec<ThreadComment>>
     let response = client.forum().get_thread_comments(thread_id, Some(1), Some(20)).await?;
 
     println!("Comments:");
-    for comment in &response.data.page.data.thread_comments {
+    for comment in &response.data {
         if let Some(user) = &comment.user {
             println!("\n  User: {}", user.name);
         }
@@ -412,17 +436,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Get User Activities
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
+use anilist_moe::unions::activity::ActivityUnion;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
-    let response = client.activity().get_recent(Some(1), Some(20)).await?;
+    // Returns Page<Vec<ActivityUnion>>
+    let response = client.activity().get_recent_activities(Some(1), Some(20)).await?;
 
-    for activity in &response.data.page.data.activities {
+    for activity in &response.data {
         match activity {
-            crate::unions::activity::ActivityUnion::TextActivity(text) => {
+            ActivityUnion::TextActivity(text) => {
                 if let Some(user) = &text.user {
                     println!("Text Activity by {}", user.name);
                 }
@@ -430,12 +456,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("  {}", text_content);
                 }
             },
-            crate::unions::activity::ActivityUnion::MessageActivity(msg) => {
+            ActivityUnion::MessageActivity(msg) => {
                 if let Some(messenger) = &msg.messenger {
                     println!("Message by {}", messenger.name);
                 }
             },
-            crate::unions::activity::ActivityUnion::ListActivity(list) => {
+            ActivityUnion::ListActivity(list) => {
                 if let Some(user) = &list.user {
                     println!("List Activity by {}", user.name);
                 }
@@ -452,7 +478,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Pagination with Error Handling
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 use anilist_moe::errors::AniListError;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -465,27 +491,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let max_pages = 5;
 
     while page <= max_pages {
-        match client.anime().get_popular(Some(page), Some(per_page)).await {
+        match client.anime().get_popular_anime(Some(page), Some(per_page)).await {
             Ok(response) => {
-                let page_info = &response.data.page.page_info;
-
-                // Process anime
-                for anime in &response.data.page.data.media {
-                    if let Some(title) = &anime.title {
-                        println!("Anime: {}", title.romaji.as_ref().unwrap_or(&"Unknown".to_string()));
+                // Access pagination info
+                if let Some(page_info) = &response.page_info {
+                    // Process anime
+                    for anime in &response.data {
+                        if let Some(title) = &anime.title {
+                            println!("Anime: {}", title.romaji.as_ref().unwrap_or(&"Unknown".to_string()));
+                        }
                     }
-                }
 
-                // Check if there are more pages
-                if !page_info.has_next_page.unwrap_or(false) {
-                    println!("No more pages");
+                    // Check if there are more pages
+                    if !page_info.has_next_page.unwrap_or(false) {
+                        println!("No more pages");
+                        break;
+                    }
+
+                    page += 1;
+
+                    // Rate limiting - be nice to the API
+                    sleep(Duration::from_millis(700)).await;
+                } else {
                     break;
                 }
-
-                page += 1;
-
-                // Rate limiting - be nice to the API
-                sleep(Duration::from_millis(700)).await;
             }
             Err(AniListError::RateLimit) => {
                 eprintln!("Rate limited, waiting 60 seconds...");
@@ -506,7 +535,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Concurrent Requests
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 use tokio::try_join;
 
 #[tokio::main]
@@ -515,15 +544,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Fetch multiple things concurrently
     let (anime, manga, characters) = try_join!(
-        client.anime().get_popular(Some(1), Some(5)),
-        client.manga().get_popular(Some(1), Some(5)),
-        client.character().get_popular(Some(1), Some(5))
+        client.anime().get_popular_anime(Some(1), Some(5)),
+        client.manga().get_popular_manga(Some(1), Some(5)),
+        client.character().get_popular_characters(Some(1), Some(5))
     )?;
 
     println!("Fetched:");
-    println!("  {} anime", anime.data.page.data.media.len());
-    println!("  {} manga", manga.data.page.data.media.len());
-    println!("  {} characters", characters.data.page.data.characters.len());
+    println!("  {} anime", anime.data.len());
+    println!("  {} manga", manga.data.len());
+    println!("  {} characters", characters.data.len());
 
     Ok(())
 }
@@ -532,8 +561,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Building a Simple Anime Tracker
 
 ```rust
-use anilist_moe::client::AniListClient;
-use std::collections::HashMap;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -541,18 +569,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Get user's anime list (requires authentication)
     let token = std::env::var("ANILIST_TOKEN")?;
-    let auth_client = AniListClient::with_token(token);
+    let auth_client = AniListClient::with_token(&token);
 
+    // Returns User directly
     let current_user = auth_client.user().get_current_user().await?;
-    let username = &current_user.data.viewer.name;
+    let username = &current_user.name;
 
-    // Get watching list
+    // Get watching list - Returns Page<Vec<MediaList>>
     let watching = auth_client.medialist()
         .get_user_anime_list(username, Some("CURRENT"), Some(1), Some(50))
         .await?;
 
     println!("Currently Watching:");
-    for entry in &watching.data.page.data.media_list {
+    for entry in &watching.data {
         if let Some(media) = &entry.media {
             if let Some(title) = &media.title {
                 println!("  - {}", title.romaji.as_ref().unwrap_or(&"Unknown".to_string()));
@@ -571,17 +600,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Type-Safe Response Access
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
-    // All responses are fully typed
-    let response = client.anime().get_by_id(1).await?;
-
-    // Type-safe access to nested data
-    let anime = &response.data.media;
+    // Returns Media directly (not wrapped)
+    let anime = client.anime().get_by_id(1).await?;
 
     // Option handling with map/and_then
     let title = anime.title.as_ref()
@@ -611,7 +637,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Comprehensive Error Handling
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 use anilist_moe::errors::AniListError;
 
 #[tokio::main]
@@ -619,8 +645,8 @@ async fn main() {
     let client = AniListClient::new();
 
     match client.anime().get_by_id(999999).await {
-        Ok(response) => {
-            println!("Success: {:?}", response);
+        Ok(anime) => {
+            println!("Success: {:?}", anime);
         }
         Err(AniListError::Network(e)) => {
             eprintln!("Network error: {}", e);
@@ -654,7 +680,7 @@ async fn main() {
 ```rust
 #[cfg(test)]
 mod tests {
-    use anilist_moe::client::AniListClient;
+    use anilist_moe::AniListClient;
 
     #[tokio::test]
     async fn test_get_anime() {
@@ -662,18 +688,18 @@ mod tests {
         let result = client.anime().get_by_id(1).await;
         assert!(result.is_ok());
 
-        let response = result.unwrap();
-        assert_eq!(response.data.media.id, 1);
+        let anime = result.unwrap();
+        assert_eq!(anime.id, Some(1));
     }
 
     #[tokio::test]
     async fn test_search_anime() {
         let client = AniListClient::new();
-        let result = client.anime().search("Cowboy Bebop", Some(1), Some(5)).await;
+        let result = client.anime().search_anime("Cowboy Bebop", Some(1), Some(5)).await;
         assert!(result.is_ok());
 
         let response = result.unwrap();
-        assert!(!response.data.page.data.media.is_empty());
+        assert!(!response.data.is_empty());
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A comprehensive, type-safe Rust wrapper for the [AniList GraphQL API](https://an
 ## Features
 
 - **Type Safety**: Fully typed responses with proper error handling
+- **Simplified Response Format**: Clean and intuitive API responses (v0.2.2+)
 - **Modular Design**: Organized endpoints for all AniList features
 - **Authentication Support**: Both authenticated and unauthenticated clients
 - **Async/Await**: Built with Tokio for high-performance asynchronous operations
@@ -17,6 +18,7 @@ A comprehensive, type-safe Rust wrapper for the [AniList GraphQL API](https://an
 - **Pagination Support**: Built-in helpers for paginated results
 - **Well Tested**: Extensive test suite covering all endpoints
 - **Convenience Functions**: Easy-to-use helper methods for common queries
+- **Code Quality**: Pre-commit hooks with Husky for consistent code style
 
 ## Supported Endpoints
 
@@ -48,7 +50,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-anilist_moe = "0.2.0"
+anilist_moe = "0.2.2"
 tokio = { version = "1.0", features = ["full"] }
 ```
 
@@ -57,7 +59,7 @@ tokio = { version = "1.0", features = ["full"] }
 ### Example 1: Get Trending Anime
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -67,10 +69,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Get trending anime with proper type safety
     let response = client.anime().get_trending(Some(1), Some(10)).await?;
 
-    // Access the data with full type information
-    let anime_list = &response.data.page.data.media;
-
-    for anime in anime_list {
+    // Access the data with clean, simple structure (v0.2.2+)
+    for anime in &response.data {
         println!(
             "Title: {} - Score: {}/100",
             anime.title.as_ref().and_then(|t| t.romaji.as_ref()).unwrap_or(&"Unknown".to_string()),
@@ -85,21 +85,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Example 2: Search and Get Detailed Information
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
     // Search for an anime
-    let search_results = client.anime().search("Attack on Titan", Some(1), Some(5)).await?;
+    let search_results = client.anime().search_anime("Attack on Titan", Some(1), Some(5)).await?;
 
-    if let Some(first_result) = search_results.data.page.data.media.first() {
-        // Get detailed information by ID
-        let anime_id = first_result.id;
-        let detailed = client.anime().get_by_id(anime_id).await?;
+    // Access the data - search_results is Page<Vec<Media>>
+    if let Some(first_result) = search_results.data.first() {
+        let anime_id = first_result.id.unwrap_or(0);
 
-        let anime = &detailed.data.media;
+        // Get detailed information by ID - returns just Media
+        let anime = client.anime().get_by_id(anime_id).await?;
 
         println!("Title: {}", anime.title.as_ref()
             .and_then(|t| t.romaji.as_ref())
@@ -126,32 +126,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Anime Operations
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
-    // Get popular anime
-    let popular = client.anime().get_popular(Some(1), Some(5)).await?;
+    // Get popular anime - returns Page<Vec<Media>>
+    let popular = client.anime().get_popular_anime(Some(1), Some(5)).await?;
+    for anime in &popular.data {
+        println!("{}", anime.title.as_ref().unwrap().romaji.as_ref().unwrap());
+    }
 
     // Get trending anime
-    let trending = client.anime().get_trending(Some(1), Some(5)).await?;
+    let trending = client.anime().get_trending_anime(Some(1), Some(5)).await?;
 
-    // Get anime by ID
+    // Get anime by ID - returns Media directly
     let anime = client.anime().get_by_id(16498).await?; // Attack on Titan
 
     // Search anime
-    let search_results = client.anime().search("Naruto", Some(1), Some(10)).await?;
+    let search_results = client.anime().search_anime("Naruto", Some(1), Some(10)).await?;
 
     // Get anime by season
-    let fall_2023 = client.anime().get_by_season("FALL", 2023, Some(1), Some(10)).await?;
+    use anilist_moe::enums::media::MediaSeason;
+    let fall_2023 = client.anime().get_by_season(MediaSeason::Fall, 2023, Some(1), Some(10)).await?;
 
     // Get top rated anime
-    let top_rated = client.anime().get_top_rated(Some(1), Some(10)).await?;
+    let top_rated = client.anime().get_top_rated_anime(Some(1), Some(10)).await?;
 
     // Get currently airing anime
-    let airing = client.anime().get_airing(Some(1), Some(10)).await?;
+    let airing = client.anime().get_airing_anime(Some(1), Some(10)).await?;
 
     Ok(())
 }
@@ -160,23 +164,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Manga Operations
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
     // Get popular manga
-    let popular = client.manga().get_popular(Some(1), Some(5)).await?;
+    let popular = client.manga().get_popular_manga(Some(1), Some(5)).await?;
 
     // Search manga
-    let search_results = client.manga().search("One Piece", Some(1), Some(10)).await?;
+    let search_results = client.manga().search_manga("One Piece", Some(1), Some(10)).await?;
 
     // Get top rated manga
-    let top_rated = client.manga().get_top_rated(Some(1), Some(10)).await?;
+    let top_rated = client.manga().get_top_rated_manga(Some(1), Some(10)).await?;
 
     // Get currently releasing manga
-    let releasing = client.manga().get_releasing(Some(1), Some(10)).await?;
+    let releasing = client.manga().get_releasing_manga(Some(1), Some(10)).await?;
 
     Ok(())
 }
@@ -185,26 +189,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Character Operations
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
-    // Get popular characters
-    let popular = client.character().get_popular(Some(1), Some(10)).await?;
+    // Get popular characters - returns Page<Vec<Character>>
+    let popular = client.character().get_popular_characters(Some(1), Some(10)).await?;
 
-    // Get character by ID
+    // Get character by ID - returns Character directly
     let character = client.character().get_by_id(40).await?; // Luffy
 
-    // Search characters
-    let search_results = client.character().search("Luffy", Some(1), Some(10)).await?;
+    // Search characters - returns Page<Vec<Character>>
+    let search_results = client.character().search_character("Luffy", Some(1), Some(10)).await?;
 
-    // Get characters with birthday today
+    // Get characters with birthday today - returns Page<Vec<Character>>
     let birthday_chars = client.character().get_by_birthday(5, 5, Some(1), Some(10)).await?;
 
-    // Get most favorited characters
-    let most_favorited = client.character().get_most_favorited(Some(1), Some(10)).await?;
+    // Get most favorited characters - returns Page<Vec<Character>>
+    let most_favorited = client.character().get_most_favorited_characters(Some(1), Some(10)).await?;
 
     Ok(())
 }
@@ -213,26 +217,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Forum Operations
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
-    // Get recent threads
-    let recent = client.forum().get_recent(Some(1), Some(10)).await?;
+    // Get recent threads - returns Page<Vec<Thread>>
+    let recent = client.forum().get_recent_threads(Some(1), Some(10)).await?;
 
-    for thread in &recent.data.page.data.threads {
+    for thread in &recent.data {
         println!("Thread: {}", thread.title.as_ref().unwrap_or(&"Untitled".to_string()));
     }
 
-    // Search threads
-    let search = client.forum().search("recommendation", Some(1), Some(10)).await?;
+    // Search threads - returns Page<Vec<Thread>>
+    let search = client.forum().search_thread("recommendation", Some(1), Some(10)).await?;
 
-    // Get thread by ID
-    let thread = client.forum().get_by_id(12345).await?;
+    // Get thread by ID - returns Thread directly
+    let thread = client.forum().get_thread_by_id(12345).await?;
 
-    // Get thread comments
+    // Get thread comments - returns Page<Vec<ThreadComment>>
     let comments = client.forum().get_thread_comments(12345, Some(1), Some(20)).await?;
 
     Ok(())
@@ -244,21 +248,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 For endpoints requiring authentication:
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create an authenticated client
     let token = std::env::var("ANILIST_TOKEN")?;
-    let client = AniListClient::with_token(token);
+    let client = AniListClient::with_token(&token);
 
-    // Get current user information
+    // Get current user information - returns User directly
     let current_user = client.user().get_current_user().await?;
-    println!("Logged in as: {}", current_user.data.viewer.name);
+    println!("Logged in as: {}", current_user.name);
 
-    // Get current user's anime list
+    // Get current user's anime list - returns Page<Vec<MediaList>>
     let anime_list = client.medialist()
-        .get_user_anime_list("username", None, Some(1), Some(50))
+        .get_user_anime_list(&current_user.name, None, Some(1), Some(50))
         .await?;
 
     Ok(())
@@ -279,7 +283,7 @@ To get an access token for authentication:
 The library provides comprehensive error handling:
 
 ```rust
-use anilist_moe::{client::AniListClient, errors::AniListError};
+use anilist_moe::{AniListClient, errors::AniListError};
 
 #[tokio::main]
 async fn main() {
@@ -301,15 +305,21 @@ async fn main() {
 All responses are fully typed. No more dealing with `serde_json::Value`:
 
 ```rust
-// Fully typed response
-let response = client.anime().get_trending(Some(1), Some(10)).await?;
+// Fully typed response - Page<Vec<Media>>
+let response = client.anime().get_trending_anime(Some(1), Some(10)).await?;
 
-// Access nested data with type safety
-let anime = &response.data.page.data.media[0];
+// Access the Vec<Media> directly through response.data
+let anime = &response.data[0];
 let title = anime.title.as_ref().unwrap();
 let romaji_title = &title.romaji;
 let score = anime.average_score.unwrap_or(0);
 let genres = anime.genres.as_ref().unwrap();
+
+// Access pagination info
+if let Some(page_info) = &response.page_info {
+    println!("Current page: {:?}", page_info.current_page);
+    println!("Has next page: {:?}", page_info.has_next_page);
+}
 ```
 
 ## Data Models
@@ -350,6 +360,7 @@ The library includes comprehensive tests for:
 The AniList API has rate limiting (90 requests per minute). The client handles basic error responses, but you should implement your own rate limiting logic for production applications:
 
 ```rust
+use anilist_moe::{AniListClient, errors::AniListError};
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -358,7 +369,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = AniListClient::new();
 
     for page in 1..=10 {
-        match client.anime().get_popular(Some(page), Some(50)).await {
+        match client.anime().get_popular_anime(Some(page), Some(50)).await {
             Ok(response) => {
                 // Process response
             }
@@ -383,7 +394,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 All list endpoints support pagination:
 
 ```rust
-use anilist_moe::client::AniListClient;
+use anilist_moe::AniListClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -393,16 +404,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let per_page = 50;
 
     loop {
-        let response = client.anime().get_popular(Some(page), Some(per_page)).await?;
-        let page_info = &response.data.page.page_info;
+        let response = client.anime().get_popular_anime(Some(page), Some(per_page)).await?;
 
-        // Process current page
-        for anime in &response.data.page.data.media {
+        // Process current page - response.data is Vec<Media>
+        for anime in &response.data {
             println!("{:?}", anime.title);
         }
 
-        // Check if there are more pages
-        if !page_info.has_next_page.unwrap_or(false) {
+        // Check pagination info
+        if let Some(page_info) = &response.page_info {
+            if !page_info.has_next_page.unwrap_or(false) {
+                break;
+            }
+        } else {
             break;
         }
 
@@ -415,27 +429,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-### Development Setup
-
-```bash
-# Clone the repository
-git clone https://github.com/Thunder-Blaze/anilist_moe.git
-cd anilist_moe
-
-# Run tests
-cargo test
-
-# Run tests with output
-cargo test -- --nocapture
-
-# Check code formatting
-cargo fmt --check
-
-# Run clippy
-cargo clippy
-```
+Contributions are welcome! Please feel free to submit a Pull Request. See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
 
 ## License
 
@@ -443,22 +437,11 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 ## Resources
 
-- [AniList API Documentation](https://anilist.gitbook.io/anilist-apiv2-docs/)
-- [AniList GraphQL Explorer](https://anilist.co/graphiql)
+- [AniList API Documentation](https://docs.anilist.co/)
+- [Apollo GraphQL Explorer](https://studio.apollographql.com/sandbox/explorer)
 - [Crates.io Package](https://crates.io/crates/anilist_moe)
 - [Documentation](https://docs.rs/anilist_moe)
 
 ## Changelog
 
-### Version 0.2.0
-
-- **Type Safety Improvements**: All endpoints now return properly typed responses instead of `serde_json::Value`
-- **Forum Endpoints**: Added full type safety for forum/thread operations
-- **Response Types**: Added comprehensive response wrapper types for all endpoints
-- **Convenience Functions**: Added 80+ convenience functions across all endpoints for easier API usage
-- **Bug Fixes**: Fixed ActivityUnion deserialization with tagged union approach
-- **Breaking Changes**: All return types have changed from `Value` to strongly typed responses
-
-### Version 0.1.0
-
-- Initial release with basic endpoint support
+See [CHANGELOG.md](CHANGELOG.md) for detailed version history.

--- a/src/endpoints/activity.rs
+++ b/src/endpoints/activity.rs
@@ -1,10 +1,11 @@
 use crate::enums::activity::{ActivitySort, ActivityType};
 use crate::errors::AniListError;
+use crate::objects::activity::{ActivityReply, MessageActivity, TextActivity};
+use crate::objects::common::Deleted;
 use crate::objects::responses::{
-    ActivityListResponse, ActivityReplyListResponse, ActivitySingleResponse,
-    DeleteActivityReplyResponse, DeleteActivityResponse, SaveActivityReplyResponse,
-    SaveMessageActivityResponse, SaveTextActivityResponse,
+    GraphQLResponse, Page
 };
+use crate::unions::activity::ActivityUnion;
 use crate::{client::AniListClient, queries::activity};
 use serde::Serialize;
 use serde_json::json;
@@ -12,7 +13,7 @@ use serde_with::skip_serializing_none;
 
 /// Options for fetching activity feed entries.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchActivityOptions {
     // # Pagination
     #[serde(rename = "page")]
@@ -80,14 +81,14 @@ pub struct FetchActivityOptions {
 }
 
 /// Options for fetching a single activity by ID.
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchActivityOneOptions {
     pub id: i32,
 }
 
 /// Options for fetching replies to an activity.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchActivityRepliesOptions {
     // # Pagination
     #[serde(rename = "page")]
@@ -103,26 +104,26 @@ pub struct FetchActivityRepliesOptions {
 }
 
 /// Options for deleting an activity.
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct DeleteActivityOptions {
     pub id: i32,
 }
 
 /// Options for deleting an activity reply.
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct DeleteActivityReplyOptions {
     pub id: i32,
 }
 
 /// Options for pinning or unpinning an activity.
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct PinActivityOptions {
     pub id: i32,
     pub pinned: bool,
 }
 
 /// Options for subscribing or unsubscribing to an activity.
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct SubscribeActivityOptions {
     pub id: i32,
     pub subscribe: bool,
@@ -130,7 +131,7 @@ pub struct SubscribeActivityOptions {
 
 /// Options for saving a message activity.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct SaveMessageActivityOptions {
     pub id: Option<i32>,
     pub message: String,
@@ -143,7 +144,7 @@ pub struct SaveMessageActivityOptions {
 
 /// Options for saving a text activity.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct SaveTextActivityOptions {
     pub id: Option<i32>,
     pub text: String,
@@ -152,7 +153,7 @@ pub struct SaveTextActivityOptions {
 
 /// Options for saving a reply to an activity.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct SaveActivityReplyOptions {
     pub id: Option<i32>,
     pub text: String,
@@ -172,102 +173,142 @@ impl ActivityEndpoint {
 
     pub async fn fetch(
         &self,
-        options: FetchActivityOptions,
-    ) -> Result<ActivityListResponse, AniListError> {
+        options: &FetchActivityOptions,
+    ) -> Result<Page<Vec<ActivityUnion>>, AniListError> {
         let query = activity::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<ActivityUnion>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn fetch_one(
         &self,
-        options: FetchActivityOneOptions,
-    ) -> Result<ActivitySingleResponse, AniListError> {
+        options: &FetchActivityOneOptions,
+    ) -> Result<ActivityUnion, AniListError> {
         let query = activity::FETCH_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<ActivityUnion>, AniListError> =self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn fetch_replies(
         &self,
-        options: FetchActivityRepliesOptions,
-    ) -> Result<ActivityReplyListResponse, AniListError> {
+        options: &FetchActivityRepliesOptions,
+    ) -> Result<Page<Vec<ActivityReply>>, AniListError> {
         let query = activity::FETCH_REPLIES;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<ActivityReply>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn delete(
         &self,
-        options: DeleteActivityOptions,
-    ) -> Result<DeleteActivityResponse, AniListError> {
+        options: &DeleteActivityOptions,
+    ) -> Result<bool, AniListError> {
         let query = activity::DELETE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Deleted>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data.deleted.unwrap_or_default()),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn delete_reply(
         &self,
-        options: DeleteActivityReplyOptions,
-    ) -> Result<DeleteActivityReplyResponse, AniListError> {
+        options: &DeleteActivityReplyOptions,
+    ) -> Result<bool, AniListError> {
         let query = activity::DELETE_REPLY;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Deleted>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data.deleted.unwrap_or_default()),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn pin(
         &self,
-        options: PinActivityOptions,
-    ) -> Result<ActivitySingleResponse, AniListError> {
+        options: &PinActivityOptions,
+    ) -> Result<ActivityUnion, AniListError> {
         let query = activity::PIN;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<ActivityUnion>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn subscribe(
         &self,
-        options: SubscribeActivityOptions,
-    ) -> Result<ActivitySingleResponse, AniListError> {
+        options: &SubscribeActivityOptions,
+    ) -> Result<ActivityUnion, AniListError> {
         let query = activity::SUBSCRIBE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<ActivityUnion>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn save_message_activity(
         &self,
-        options: SaveMessageActivityOptions,
-    ) -> Result<SaveMessageActivityResponse, AniListError> {
+        options: &SaveMessageActivityOptions,
+    ) -> Result<ActivityUnion, AniListError> {
         let query = activity::SAVE_MESSAGE_ACTIVITY;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<MessageActivity>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(ActivityUnion::MessageActivity(res.data)),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn save_text_activity(
         &self,
-        options: SaveTextActivityOptions,
-    ) -> Result<SaveTextActivityResponse, AniListError> {
+        options: &SaveTextActivityOptions,
+    ) -> Result<ActivityUnion, AniListError> {
         let query = activity::SAVE_TEXT_ACTIVITY;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<TextActivity>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(ActivityUnion::TextActivity(res.data)),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn save_reply(
         &self,
-        options: SaveActivityReplyOptions,
-    ) -> Result<SaveActivityReplyResponse, AniListError> {
+        options: &SaveActivityReplyOptions,
+    ) -> Result<ActivityReply, AniListError> {
         let query = activity::SAVE_REPLY;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<ActivityReply>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     // Convenience functions
@@ -277,8 +318,8 @@ impl ActivityEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<ActivityListResponse, AniListError> {
-        self.fetch(FetchActivityOptions {
+    ) -> Result<Page<Vec<ActivityUnion>>, AniListError> {
+        self.fetch(&FetchActivityOptions {
             page,
             per_page,
             sort: Some(vec![ActivitySort::IdDesc]),
@@ -292,8 +333,8 @@ impl ActivityEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<ActivityListResponse, AniListError> {
-        self.fetch(FetchActivityOptions {
+    ) -> Result<Page<Vec<ActivityUnion>>, AniListError> {
+        self.fetch(&FetchActivityOptions {
             is_following: Some(true),
             page,
             per_page,
@@ -304,16 +345,16 @@ impl ActivityEndpoint {
     }
 
     /// Get activity by ID
-    pub async fn get_by_id(&self, id: i32) -> Result<ActivitySingleResponse, AniListError> {
-        self.fetch_one(FetchActivityOneOptions { id }).await
+    pub async fn get_by_id(&self, id: i32) -> Result<ActivityUnion, AniListError> {
+        self.fetch_one(&FetchActivityOneOptions { id }).await
     }
 
     /// Create a text activity
     pub async fn create_text_activity(
         &self,
         text: &str,
-    ) -> Result<SaveTextActivityResponse, AniListError> {
-        self.save_text_activity(SaveTextActivityOptions {
+    ) -> Result<ActivityUnion, AniListError> {
+        self.save_text_activity(&SaveTextActivityOptions {
             id: None,
             text: text.to_string(),
             locked: None,
@@ -327,8 +368,8 @@ impl ActivityEndpoint {
         recipient_id: i32,
         message: &str,
         private: Option<bool>,
-    ) -> Result<SaveMessageActivityResponse, AniListError> {
-        self.save_message_activity(SaveMessageActivityOptions {
+    ) -> Result<ActivityUnion, AniListError> {
+        self.save_message_activity(&SaveMessageActivityOptions {
             id: None,
             message: message.to_string(),
             recipient_id,
@@ -344,8 +385,8 @@ impl ActivityEndpoint {
         &self,
         activity_id: i32,
         text: &str,
-    ) -> Result<SaveActivityReplyResponse, AniListError> {
-        self.save_reply(SaveActivityReplyOptions {
+    ) -> Result<ActivityReply, AniListError> {
+        self.save_reply(&SaveActivityReplyOptions {
             id: None,
             text: text.to_string(),
             activity_id,
@@ -354,16 +395,16 @@ impl ActivityEndpoint {
     }
 
     /// Delete an activity
-    pub async fn delete_activity(&self, id: i32) -> Result<DeleteActivityResponse, AniListError> {
-        self.delete(DeleteActivityOptions { id }).await
+    pub async fn delete_activity(&self, id: i32) -> Result<bool, AniListError> {
+        self.delete(&DeleteActivityOptions { id }).await
     }
 
     /// Delete an activity reply
     pub async fn delete_activity_reply(
         &self,
         id: i32,
-    ) -> Result<DeleteActivityReplyResponse, AniListError> {
-        self.delete_reply(DeleteActivityReplyOptions { id }).await
+    ) -> Result<bool, AniListError> {
+        self.delete_reply(&DeleteActivityReplyOptions { id }).await
     }
 
     /// Toggle activity subscription
@@ -371,8 +412,8 @@ impl ActivityEndpoint {
         &self,
         id: i32,
         subscribe: bool,
-    ) -> Result<ActivitySingleResponse, AniListError> {
-        self.subscribe(SubscribeActivityOptions { id, subscribe })
+    ) -> Result<ActivityUnion, AniListError> {
+        self.subscribe(&SubscribeActivityOptions { id, subscribe })
             .await
     }
 
@@ -381,7 +422,7 @@ impl ActivityEndpoint {
         &self,
         id: i32,
         pinned: bool,
-    ) -> Result<ActivitySingleResponse, AniListError> {
-        self.pin(PinActivityOptions { id, pinned }).await
+    ) -> Result<ActivityUnion, AniListError> {
+        self.pin(&PinActivityOptions { id, pinned }).await
     }
 }

--- a/src/endpoints/activity.rs
+++ b/src/endpoints/activity.rs
@@ -2,9 +2,7 @@ use crate::enums::activity::{ActivitySort, ActivityType};
 use crate::errors::AniListError;
 use crate::objects::activity::{ActivityReply, MessageActivity, TextActivity};
 use crate::objects::common::Deleted;
-use crate::objects::responses::{
-    GraphQLResponse, Page
-};
+use crate::objects::responses::{GraphQLResponse, Page};
 use crate::unions::activity::ActivityUnion;
 use crate::{client::AniListClient, queries::activity};
 use serde::Serialize;
@@ -178,7 +176,8 @@ impl ActivityEndpoint {
         let query = activity::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<ActivityUnion>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<ActivityUnion>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -192,7 +191,8 @@ impl ActivityEndpoint {
         let query = activity::FETCH_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<ActivityUnion>, AniListError> =self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<ActivityUnion>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -206,21 +206,20 @@ impl ActivityEndpoint {
         let query = activity::FETCH_REPLIES;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<ActivityReply>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<ActivityReply>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
         }
     }
 
-    pub async fn delete(
-        &self,
-        options: &DeleteActivityOptions,
-    ) -> Result<bool, AniListError> {
+    pub async fn delete(&self, options: &DeleteActivityOptions) -> Result<bool, AniListError> {
         let query = activity::DELETE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Deleted>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Deleted>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data.deleted.unwrap_or_default()),
             Err(err) => Err(err),
@@ -234,21 +233,20 @@ impl ActivityEndpoint {
         let query = activity::DELETE_REPLY;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Deleted>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Deleted>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data.deleted.unwrap_or_default()),
             Err(err) => Err(err),
         }
     }
 
-    pub async fn pin(
-        &self,
-        options: &PinActivityOptions,
-    ) -> Result<ActivityUnion, AniListError> {
+    pub async fn pin(&self, options: &PinActivityOptions) -> Result<ActivityUnion, AniListError> {
         let query = activity::PIN;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<ActivityUnion>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<ActivityUnion>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -262,7 +260,8 @@ impl ActivityEndpoint {
         let query = activity::SUBSCRIBE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<ActivityUnion>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<ActivityUnion>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -276,7 +275,8 @@ impl ActivityEndpoint {
         let query = activity::SAVE_MESSAGE_ACTIVITY;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<MessageActivity>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<MessageActivity>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(ActivityUnion::MessageActivity(res.data)),
             Err(err) => Err(err),
@@ -290,7 +290,8 @@ impl ActivityEndpoint {
         let query = activity::SAVE_TEXT_ACTIVITY;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<TextActivity>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<TextActivity>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(ActivityUnion::TextActivity(res.data)),
             Err(err) => Err(err),
@@ -304,7 +305,8 @@ impl ActivityEndpoint {
         let query = activity::SAVE_REPLY;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<ActivityReply>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<ActivityReply>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -350,10 +352,7 @@ impl ActivityEndpoint {
     }
 
     /// Create a text activity
-    pub async fn create_text_activity(
-        &self,
-        text: &str,
-    ) -> Result<ActivityUnion, AniListError> {
+    pub async fn create_text_activity(&self, text: &str) -> Result<ActivityUnion, AniListError> {
         self.save_text_activity(&SaveTextActivityOptions {
             id: None,
             text: text.to_string(),
@@ -400,10 +399,7 @@ impl ActivityEndpoint {
     }
 
     /// Delete an activity reply
-    pub async fn delete_activity_reply(
-        &self,
-        id: i32,
-    ) -> Result<bool, AniListError> {
+    pub async fn delete_activity_reply(&self, id: i32) -> Result<bool, AniListError> {
         self.delete_reply(&DeleteActivityReplyOptions { id }).await
     }
 
@@ -418,11 +414,7 @@ impl ActivityEndpoint {
     }
 
     /// Toggle activity pin status
-    pub async fn toggle_pin(
-        &self,
-        id: i32,
-        pinned: bool,
-    ) -> Result<ActivityUnion, AniListError> {
+    pub async fn toggle_pin(&self, id: i32, pinned: bool) -> Result<ActivityUnion, AniListError> {
         self.pin(&PinActivityOptions { id, pinned }).await
     }
 }

--- a/src/endpoints/activity.rs
+++ b/src/endpoints/activity.rs
@@ -8,75 +8,74 @@ use crate::objects::responses::{
 use crate::{client::AniListClient, queries::activity};
 use serde::Serialize;
 use serde_json::json;
+use serde_with::skip_serializing_none;
 
 /// Options for fetching activity feed entries.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchActivityOptions {
     // # Pagination
-    #[serde(rename = "page", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "page")]
     pub page: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
 
     // # Filters
-    #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id")]
     pub id: Option<i32>,
-    #[serde(rename = "userId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "userId")]
     pub user_id: Option<i32>,
-    #[serde(rename = "messengerId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "messengerId")]
     pub messenger_id: Option<i32>,
-    #[serde(rename = "mediaId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaId")]
     pub media_id: Option<i32>,
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type")]
     pub type_: Option<ActivityType>,
-    #[serde(rename = "isFollowing", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "isFollowing")]
     pub is_following: Option<bool>,
-    #[serde(rename = "hasReplies", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "hasReplies")]
     pub has_replies: Option<bool>,
-    #[serde(
-        rename = "hasRepliesOrTypeText",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "hasRepliesOrTypeText")]
     pub has_replies_or_type_text: Option<bool>,
-    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "createdAt")]
     pub created_at: Option<i32>,
-    #[serde(rename = "id_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_not")]
     pub id_not: Option<i32>,
-    #[serde(rename = "id_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_in")]
     pub id_in: Option<Vec<i32>>,
-    #[serde(rename = "id_not_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_not_in")]
     pub id_not_in: Option<Vec<i32>>,
-    #[serde(rename = "userId_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "userId_not")]
     pub user_id_not: Option<i32>,
-    #[serde(rename = "userId_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "userId_in")]
     pub user_id_in: Option<Vec<i32>>,
-    #[serde(rename = "userId_not_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "userId_not_in")]
     pub user_id_not_in: Option<Vec<i32>>,
-    #[serde(rename = "messengerId_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "messengerId_not")]
     pub messenger_id_not: Option<i32>,
-    #[serde(rename = "messengerId_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "messengerId_in")]
     pub messenger_id_in: Option<Vec<i32>>,
-    #[serde(rename = "messengerId_not_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "messengerId_not_in")]
     pub messenger_id_not_in: Option<Vec<i32>>,
-    #[serde(rename = "mediaId_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaId_not")]
     pub media_id_not: Option<i32>,
-    #[serde(rename = "mediaId_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaId_in")]
     pub media_id_in: Option<Vec<i32>>,
-    #[serde(rename = "mediaId_not_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaId_not_in")]
     pub media_id_not_in: Option<Vec<i32>>,
-    #[serde(rename = "type_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type_not")]
     pub type_not: Option<ActivityType>,
-    #[serde(rename = "type_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type_in")]
     pub type_in: Option<Vec<ActivityType>>,
-    #[serde(rename = "type_not_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type_not_in")]
     pub type_not_in: Option<Vec<ActivityType>>,
-    #[serde(rename = "createdAt_greater", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "createdAt_greater")]
     pub created_at_greater: Option<i32>,
-    #[serde(rename = "createdAt_lesser", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "createdAt_lesser")]
     pub created_at_lesser: Option<i32>,
 
     // # Sort
-    #[serde(rename = "sort", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "sort")]
     pub sort: Option<Vec<ActivitySort>>,
 }
 
@@ -87,16 +86,17 @@ pub struct FetchActivityOneOptions {
 }
 
 /// Options for fetching replies to an activity.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchActivityRepliesOptions {
     // # Pagination
-    #[serde(rename = "page", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "page")]
     pub page: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
 
     // # Filters
-    #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id")]
     pub id: Option<i32>,
     #[serde(rename = "activityId")]
     pub activity_id: i32,
@@ -129,35 +129,31 @@ pub struct SubscribeActivityOptions {
 }
 
 /// Options for saving a message activity.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct SaveMessageActivityOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
     pub message: String,
     #[serde(rename = "recipientId")]
     pub recipient_id: i32,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub private: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub locked: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub as_mod: Option<bool>,
 }
 
 /// Options for saving a text activity.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct SaveTextActivityOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
     pub text: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub locked: Option<bool>,
 }
 
 /// Options for saving a reply to an activity.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct SaveActivityReplyOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
     pub text: String,
     #[serde(rename = "activityId")]

--- a/src/endpoints/airing.rs
+++ b/src/endpoints/airing.rs
@@ -1,13 +1,15 @@
 use crate::errors::AniListError;
+use crate::objects::airing::AiringSchedule;
+use crate::objects::responses::{GraphQLResponse, Page};
 use crate::{client::AniListClient, queries::airing};
-use crate::{enums::airing::AiringSort, objects::responses::AiringListResponse};
+use crate::{enums::airing::AiringSort};
 use serde::Serialize;
 use serde_json::json;
 use serde_with::skip_serializing_none;
 
 /// Options for fetching airing schedule information.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchAiringOptions {
     pub id: Option<i32>,
     #[serde(rename = "mediaId")]
@@ -61,12 +63,16 @@ impl AiringEndpoint {
 
     pub async fn fetch(
         &self,
-        options: FetchAiringOptions,
-    ) -> Result<AiringListResponse, AniListError> {
+        options: &FetchAiringOptions,
+    ) -> Result<Page<Vec<AiringSchedule>>, AniListError> {
         let query = airing::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<AiringSchedule>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     // Convenience functions
@@ -76,13 +82,13 @@ impl AiringEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<AiringListResponse, AniListError> {
+    ) -> Result<Page<Vec<AiringSchedule>>, AniListError> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs() as i32;
 
-        self.fetch(FetchAiringOptions {
+        self.fetch(&FetchAiringOptions {
             airing_at_greater: Some(now),
             sort: Some(vec![AiringSort::Time]),
             page,
@@ -97,13 +103,13 @@ impl AiringEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<AiringListResponse, AniListError> {
+    ) -> Result<Page<Vec<AiringSchedule>>, AniListError> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs() as i32;
 
-        self.fetch(FetchAiringOptions {
+        self.fetch(&FetchAiringOptions {
             airing_at_lesser: Some(now),
             sort: Some(vec![AiringSort::TimeDesc]),
             page,
@@ -119,8 +125,8 @@ impl AiringEndpoint {
         media_id: i32,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<AiringListResponse, AniListError> {
-        self.fetch(FetchAiringOptions {
+    ) -> Result<Page<Vec<AiringSchedule>>, AniListError> {
+        self.fetch(&FetchAiringOptions {
             media_id: Some(media_id),
             sort: Some(vec![AiringSort::Time]),
             page,

--- a/src/endpoints/airing.rs
+++ b/src/endpoints/airing.rs
@@ -1,8 +1,8 @@
+use crate::enums::airing::AiringSort;
 use crate::errors::AniListError;
 use crate::objects::airing::AiringSchedule;
 use crate::objects::responses::{GraphQLResponse, Page};
 use crate::{client::AniListClient, queries::airing};
-use crate::{enums::airing::AiringSort};
 use serde::Serialize;
 use serde_json::json;
 use serde_with::skip_serializing_none;
@@ -68,7 +68,8 @@ impl AiringEndpoint {
         let query = airing::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<AiringSchedule>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<AiringSchedule>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),

--- a/src/endpoints/airing.rs
+++ b/src/endpoints/airing.rs
@@ -3,51 +3,49 @@ use crate::{client::AniListClient, queries::airing};
 use crate::{enums::airing::AiringSort, objects::responses::AiringListResponse};
 use serde::Serialize;
 use serde_json::json;
+use serde_with::skip_serializing_none;
 
 /// Options for fetching airing schedule information.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchAiringOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(rename = "mediaId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaId")]
     pub media_id: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub episode: Option<i32>,
-    #[serde(rename = "airingAt", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "airingAt")]
     pub airing_at: Option<i32>,
-    #[serde(rename = "notYetAired", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "notYetAired")]
     pub not_yet_aired: Option<bool>,
-    #[serde(rename = "id_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_not")]
     pub id_not: Option<i32>,
-    #[serde(rename = "id_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_in")]
     pub id_in: Option<Vec<i32>>,
-    #[serde(rename = "id_not_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_not_in")]
     pub id_not_in: Option<Vec<i32>>,
-    #[serde(rename = "mediaId_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaId_not")]
     pub media_id_not: Option<i32>,
-    #[serde(rename = "mediaId_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaId_in")]
     pub media_id_in: Option<Vec<i32>>,
-    #[serde(rename = "mediaId_not_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaId_not_in")]
     pub media_id_not_in: Option<Vec<i32>>,
-    #[serde(rename = "episode_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "episode_not")]
     pub episode_not: Option<i32>,
-    #[serde(rename = "episode_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "episode_in")]
     pub episode_in: Option<Vec<i32>>,
-    #[serde(rename = "episode_not_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "episode_not_in")]
     pub episode_not_in: Option<Vec<i32>>,
-    #[serde(rename = "episode_greater", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "episode_greater")]
     pub episode_greater: Option<i32>,
-    #[serde(rename = "episode_lesser", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "episode_lesser")]
     pub episode_lesser: Option<i32>,
-    #[serde(rename = "airingAt_greater", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "airingAt_greater")]
     pub airing_at_greater: Option<i32>,
-    #[serde(rename = "airingAt_lesser", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "airingAt_lesser")]
     pub airing_at_lesser: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<AiringSort>>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,
 }
 

--- a/src/endpoints/character.rs
+++ b/src/endpoints/character.rs
@@ -1,7 +1,8 @@
 use crate::enums::character::CharacterSort;
 use crate::enums::media::MediaSort;
 use crate::errors::AniListError;
-use crate::objects::responses::{CharacterListResponse, CharacterSingleResponse};
+use crate::objects::character::Character;
+use crate::objects::responses::{GraphQLResponse, Page};
 use crate::{client::AniListClient, queries::character};
 use serde::Serialize;
 use serde_json::json;
@@ -9,7 +10,7 @@ use serde_with::skip_serializing_none;
 
 /// Options for fetching multiple characters with pagination and filters.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchCharacterOptions {
     pub page: Option<i32>,
     pub id: Option<i32>,
@@ -26,7 +27,7 @@ pub struct FetchCharacterOptions {
 
 /// Options for fetching a single character.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchCharacterOneOptions {
     pub id: Option<i32>,
     #[serde(rename = "isBirthday")]
@@ -60,8 +61,8 @@ impl CharacterEndpoint {
 
     pub async fn fetch(
         &self,
-        options: FetchCharacterOptions,
-    ) -> Result<CharacterListResponse, AniListError> {
+        options: &FetchCharacterOptions,
+    ) -> Result<Page<Vec<Character>>, AniListError> {
         let query = character::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
@@ -70,12 +71,16 @@ impl CharacterEndpoint {
 
     pub async fn fetch_one(
         &self,
-        options: FetchCharacterOneOptions,
-    ) -> Result<CharacterSingleResponse, AniListError> {
+        options: &FetchCharacterOneOptions,
+    ) -> Result<Character, AniListError> {
         let query = character::FETCH_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Character>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     // Convenience functions
@@ -85,8 +90,8 @@ impl CharacterEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<CharacterListResponse, AniListError> {
-        self.fetch(FetchCharacterOptions {
+    ) -> Result<Page<Vec<Character>>, AniListError> {
+        self.fetch(&FetchCharacterOptions {
             page,
             per_page,
             sort: Some(vec![CharacterSort::FavouritesDesc]),
@@ -100,7 +105,7 @@ impl CharacterEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<CharacterListResponse, AniListError> {
+    ) -> Result<Page<Vec<Character>>, AniListError> {
         self.get_popular(page, per_page).await
     }
 
@@ -110,8 +115,8 @@ impl CharacterEndpoint {
         query: &str,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<CharacterListResponse, AniListError> {
-        self.fetch(FetchCharacterOptions {
+    ) -> Result<Page<Vec<Character>>, AniListError> {
+        self.fetch(&FetchCharacterOptions {
             search: Some(query.to_string()),
             page,
             per_page,
@@ -122,8 +127,8 @@ impl CharacterEndpoint {
     }
 
     /// Get character by ID
-    pub async fn get_by_id(&self, id: i32) -> Result<CharacterSingleResponse, AniListError> {
-        self.fetch_one(FetchCharacterOneOptions {
+    pub async fn get_by_id(&self, id: i32) -> Result<Character, AniListError> {
+        self.fetch_one(&FetchCharacterOneOptions {
             id: Some(id),
             ..Default::default()
         })
@@ -135,8 +140,8 @@ impl CharacterEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<CharacterListResponse, AniListError> {
-        self.fetch(FetchCharacterOptions {
+    ) -> Result<Page<Vec<Character>>, AniListError> {
+        self.fetch(&FetchCharacterOptions {
             is_birthday: Some(true),
             page,
             per_page,

--- a/src/endpoints/character.rs
+++ b/src/endpoints/character.rs
@@ -76,7 +76,8 @@ impl CharacterEndpoint {
         let query = character::FETCH_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Character>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Character>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),

--- a/src/endpoints/character.rs
+++ b/src/endpoints/character.rs
@@ -5,57 +5,46 @@ use crate::objects::responses::{CharacterListResponse, CharacterSingleResponse};
 use crate::{client::AniListClient, queries::character};
 use serde::Serialize;
 use serde_json::json;
+use serde_with::skip_serializing_none;
 
 /// Options for fetching multiple characters with pagination and filters.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchCharacterOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub search: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<CharacterSort>>,
-    #[serde(rename = "isBirthday", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "isBirthday")]
     pub is_birthday: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id_not: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id_in: Option<Vec<i32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id_not_in: Option<Vec<i32>>,
 }
 
 /// Options for fetching a single character.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchCharacterOneOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(rename = "isBirthday", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "isBirthday")]
     pub is_birthday: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub search: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id_not: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id_in: Option<Vec<i32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id_not_in: Option<Vec<i32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<CharacterSort>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
     // Sub-pagination variables
-    #[serde(rename = "mediaSort", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaSort")]
     pub media_sort: Option<Vec<MediaSort>>,
-    #[serde(rename = "mediaPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaPage")]
     pub media_page: Option<i32>,
-    #[serde(rename = "mediaPerPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaPerPage")]
     pub media_per_page: Option<i32>,
 }
 

--- a/src/endpoints/common.rs
+++ b/src/endpoints/common.rs
@@ -1,9 +1,7 @@
 use crate::enums::likable::LikeableType;
 use crate::errors::AniListError;
 use crate::objects::favourites::Favourites;
-use crate::objects::responses::{
-    ToggleFavouriteResponse, ToggleFollowResponse, ToggleLikeResponse,
-};
+use crate::objects::responses::GraphQLResponse;
 use crate::objects::user::User;
 use crate::unions::likeable::LikeableUnion;
 use crate::{client::AniListClient, queries::common};
@@ -59,10 +57,10 @@ impl CommonEndpoint {
         let query = common::TOGGLE_LIKE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<ToggleLikeResponse, AniListError> =
+        let response: Result<GraphQLResponse<LikeableUnion>, AniListError> =
             self.client.query_typed(query, Some(&variables_map)).await;
         match response {
-            Ok(res) => Ok(res.data.toggle_like_v2),
+            Ok(res) => Ok(res.data),
             Err(err) => Err(err),
         }
     }
@@ -71,10 +69,10 @@ impl CommonEndpoint {
         let query = common::TOGGLE_FOLLOW;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<ToggleFollowResponse, AniListError> =
+        let response: Result<GraphQLResponse<User>, AniListError> =
             self.client.query_typed(query, Some(&variables_map)).await;
         match response {
-            Ok(res) => Ok(res.data.toggle_follow),
+            Ok(res) => Ok(res.data),
             Err(err) => Err(err),
         }
     }
@@ -86,10 +84,10 @@ impl CommonEndpoint {
         let query = common::TOGGLE_FAVOURITE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<ToggleFavouriteResponse, AniListError> =
+        let response: Result<GraphQLResponse<Favourites>, AniListError> =
             self.client.query_typed(query, Some(&variables_map)).await;
         match response {
-            Ok(res) => Ok(res.data.toggle_favourite),
+            Ok(res) => Ok(res.data),
             Err(err) => Err(err),
         }
     }

--- a/src/endpoints/common.rs
+++ b/src/endpoints/common.rs
@@ -6,6 +6,7 @@ use crate::objects::responses::{
 use crate::{client::AniListClient, queries::common};
 use serde::Serialize;
 use serde_json::json;
+use serde_with::skip_serializing_none;
 
 /// Options for toggling a like on various entities.
 #[derive(Serialize)]
@@ -23,17 +24,18 @@ pub struct ToggleFollowOptions {
 }
 
 /// Options for adding or removing favourites.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct ToggleFavouriteOptions {
-    #[serde(rename = "animeId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "animeId")]
     pub anime_id: Option<i32>,
-    #[serde(rename = "mangaId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mangaId")]
     pub manga_id: Option<i32>,
-    #[serde(rename = "characterId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "characterId")]
     pub character_id: Option<i32>,
-    #[serde(rename = "staffId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "staffId")]
     pub staff_id: Option<i32>,
-    #[serde(rename = "studioId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "studioId")]
     pub studio_id: Option<i32>,
 }
 

--- a/src/endpoints/common.rs
+++ b/src/endpoints/common.rs
@@ -1,8 +1,11 @@
 use crate::enums::likable::LikeableType;
 use crate::errors::AniListError;
+use crate::objects::favourites::Favourites;
 use crate::objects::responses::{
     ToggleFavouriteResponse, ToggleFollowResponse, ToggleLikeResponse,
 };
+use crate::objects::user::User;
+use crate::unions::likeable::LikeableUnion;
 use crate::{client::AniListClient, queries::common};
 use serde::Serialize;
 use serde_json::json;
@@ -17,7 +20,7 @@ pub struct ToggleLikeOptions {
 }
 
 /// Options for toggling follow status of a user.
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct ToggleFollowOptions {
     #[serde(rename = "userId")]
     pub user_id: i32,
@@ -25,7 +28,7 @@ pub struct ToggleFollowOptions {
 
 /// Options for adding or removing favourites.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct ToggleFavouriteOptions {
     #[serde(rename = "animeId")]
     pub anime_id: Option<i32>,
@@ -51,39 +54,51 @@ impl CommonEndpoint {
 
     pub async fn toggle_like(
         &self,
-        options: ToggleLikeOptions,
-    ) -> Result<ToggleLikeResponse, AniListError> {
+        options: &ToggleLikeOptions,
+    ) -> Result<LikeableUnion, AniListError> {
         let query = common::TOGGLE_LIKE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<ToggleLikeResponse, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data.toggle_like_v2),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn toggle_follow(
         &self,
-        options: ToggleFollowOptions,
-    ) -> Result<ToggleFollowResponse, AniListError> {
+        options: &ToggleFollowOptions,
+    ) -> Result<User, AniListError> {
         let query = common::TOGGLE_FOLLOW;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<ToggleFollowResponse, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data.toggle_follow),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn toggle_favourite(
         &self,
-        options: ToggleFavouriteOptions,
-    ) -> Result<ToggleFavouriteResponse, AniListError> {
+        options: &ToggleFavouriteOptions,
+    ) -> Result<Favourites, AniListError> {
         let query = common::TOGGLE_FAVOURITE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<ToggleFavouriteResponse, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data.toggle_favourite),
+            Err(err) => Err(err),
+        }
     }
 
     // Convenience functions
 
     /// Like or unlike an activity
-    pub async fn like_activity(&self, id: i32) -> Result<ToggleLikeResponse, AniListError> {
-        self.toggle_like(ToggleLikeOptions {
+    pub async fn like_activity(&self, id: i32) -> Result<LikeableUnion, AniListError> {
+        self.toggle_like(&ToggleLikeOptions {
             id,
             like_type: LikeableType::Activity,
         })
@@ -91,8 +106,8 @@ impl CommonEndpoint {
     }
 
     /// Like or unlike an activity reply
-    pub async fn like_activity_reply(&self, id: i32) -> Result<ToggleLikeResponse, AniListError> {
-        self.toggle_like(ToggleLikeOptions {
+    pub async fn like_activity_reply(&self, id: i32) -> Result<LikeableUnion, AniListError> {
+        self.toggle_like(&ToggleLikeOptions {
             id,
             like_type: LikeableType::ActivityReply,
         })
@@ -100,8 +115,8 @@ impl CommonEndpoint {
     }
 
     /// Like or unlike a thread
-    pub async fn like_thread(&self, id: i32) -> Result<ToggleLikeResponse, AniListError> {
-        self.toggle_like(ToggleLikeOptions {
+    pub async fn like_thread(&self, id: i32) -> Result<LikeableUnion, AniListError> {
+        self.toggle_like(&ToggleLikeOptions {
             id,
             like_type: LikeableType::Thread,
         })
@@ -109,8 +124,8 @@ impl CommonEndpoint {
     }
 
     /// Like or unlike a thread comment
-    pub async fn like_thread_comment(&self, id: i32) -> Result<ToggleLikeResponse, AniListError> {
-        self.toggle_like(ToggleLikeOptions {
+    pub async fn like_thread_comment(&self, id: i32) -> Result<LikeableUnion, AniListError> {
+        self.toggle_like(&ToggleLikeOptions {
             id,
             like_type: LikeableType::ThreadComment,
         })
@@ -118,16 +133,16 @@ impl CommonEndpoint {
     }
 
     /// Follow or unfollow a user
-    pub async fn follow_user(&self, user_id: i32) -> Result<ToggleFollowResponse, AniListError> {
-        self.toggle_follow(ToggleFollowOptions { user_id }).await
+    pub async fn follow_user(&self, user_id: i32) -> Result<User, AniListError> {
+        self.toggle_follow(&ToggleFollowOptions { user_id }).await
     }
 
     /// Add or remove anime from favorites
     pub async fn favourite_anime(
         &self,
         anime_id: i32,
-    ) -> Result<ToggleFavouriteResponse, AniListError> {
-        self.toggle_favourite(ToggleFavouriteOptions {
+    ) -> Result<Favourites, AniListError> {
+        self.toggle_favourite(&ToggleFavouriteOptions {
             anime_id: Some(anime_id),
             ..Default::default()
         })
@@ -138,8 +153,8 @@ impl CommonEndpoint {
     pub async fn favourite_manga(
         &self,
         manga_id: i32,
-    ) -> Result<ToggleFavouriteResponse, AniListError> {
-        self.toggle_favourite(ToggleFavouriteOptions {
+    ) -> Result<Favourites, AniListError> {
+        self.toggle_favourite(&ToggleFavouriteOptions {
             manga_id: Some(manga_id),
             ..Default::default()
         })
@@ -150,8 +165,8 @@ impl CommonEndpoint {
     pub async fn favourite_character(
         &self,
         character_id: i32,
-    ) -> Result<ToggleFavouriteResponse, AniListError> {
-        self.toggle_favourite(ToggleFavouriteOptions {
+    ) -> Result<Favourites, AniListError> {
+        self.toggle_favourite(&ToggleFavouriteOptions {
             character_id: Some(character_id),
             ..Default::default()
         })
@@ -162,8 +177,8 @@ impl CommonEndpoint {
     pub async fn favourite_staff(
         &self,
         staff_id: i32,
-    ) -> Result<ToggleFavouriteResponse, AniListError> {
-        self.toggle_favourite(ToggleFavouriteOptions {
+    ) -> Result<Favourites, AniListError> {
+        self.toggle_favourite(&ToggleFavouriteOptions {
             staff_id: Some(staff_id),
             ..Default::default()
         })
@@ -174,8 +189,8 @@ impl CommonEndpoint {
     pub async fn favourite_studio(
         &self,
         studio_id: i32,
-    ) -> Result<ToggleFavouriteResponse, AniListError> {
-        self.toggle_favourite(ToggleFavouriteOptions {
+    ) -> Result<Favourites, AniListError> {
+        self.toggle_favourite(&ToggleFavouriteOptions {
             studio_id: Some(studio_id),
             ..Default::default()
         })

--- a/src/endpoints/common.rs
+++ b/src/endpoints/common.rs
@@ -59,21 +59,20 @@ impl CommonEndpoint {
         let query = common::TOGGLE_LIKE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<ToggleLikeResponse, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<ToggleLikeResponse, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data.toggle_like_v2),
             Err(err) => Err(err),
         }
     }
 
-    pub async fn toggle_follow(
-        &self,
-        options: &ToggleFollowOptions,
-    ) -> Result<User, AniListError> {
+    pub async fn toggle_follow(&self, options: &ToggleFollowOptions) -> Result<User, AniListError> {
         let query = common::TOGGLE_FOLLOW;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<ToggleFollowResponse, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<ToggleFollowResponse, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data.toggle_follow),
             Err(err) => Err(err),
@@ -87,7 +86,8 @@ impl CommonEndpoint {
         let query = common::TOGGLE_FAVOURITE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<ToggleFavouriteResponse, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<ToggleFavouriteResponse, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data.toggle_favourite),
             Err(err) => Err(err),
@@ -138,10 +138,7 @@ impl CommonEndpoint {
     }
 
     /// Add or remove anime from favorites
-    pub async fn favourite_anime(
-        &self,
-        anime_id: i32,
-    ) -> Result<Favourites, AniListError> {
+    pub async fn favourite_anime(&self, anime_id: i32) -> Result<Favourites, AniListError> {
         self.toggle_favourite(&ToggleFavouriteOptions {
             anime_id: Some(anime_id),
             ..Default::default()
@@ -150,10 +147,7 @@ impl CommonEndpoint {
     }
 
     /// Add or remove manga from favorites
-    pub async fn favourite_manga(
-        &self,
-        manga_id: i32,
-    ) -> Result<Favourites, AniListError> {
+    pub async fn favourite_manga(&self, manga_id: i32) -> Result<Favourites, AniListError> {
         self.toggle_favourite(&ToggleFavouriteOptions {
             manga_id: Some(manga_id),
             ..Default::default()
@@ -162,10 +156,7 @@ impl CommonEndpoint {
     }
 
     /// Add or remove character from favorites
-    pub async fn favourite_character(
-        &self,
-        character_id: i32,
-    ) -> Result<Favourites, AniListError> {
+    pub async fn favourite_character(&self, character_id: i32) -> Result<Favourites, AniListError> {
         self.toggle_favourite(&ToggleFavouriteOptions {
             character_id: Some(character_id),
             ..Default::default()
@@ -174,10 +165,7 @@ impl CommonEndpoint {
     }
 
     /// Add or remove staff from favorites
-    pub async fn favourite_staff(
-        &self,
-        staff_id: i32,
-    ) -> Result<Favourites, AniListError> {
+    pub async fn favourite_staff(&self, staff_id: i32) -> Result<Favourites, AniListError> {
         self.toggle_favourite(&ToggleFavouriteOptions {
             staff_id: Some(staff_id),
             ..Default::default()
@@ -186,10 +174,7 @@ impl CommonEndpoint {
     }
 
     /// Add or remove studio from favorites
-    pub async fn favourite_studio(
-        &self,
-        studio_id: i32,
-    ) -> Result<Favourites, AniListError> {
+    pub async fn favourite_studio(&self, studio_id: i32) -> Result<Favourites, AniListError> {
         self.toggle_favourite(&ToggleFavouriteOptions {
             studio_id: Some(studio_id),
             ..Default::default()

--- a/src/endpoints/forum.rs
+++ b/src/endpoints/forum.rs
@@ -1,9 +1,7 @@
 use crate::enums::thread::{ThreadCommentSort, ThreadSort};
 use crate::errors::AniListError;
 use crate::objects::common::Deleted;
-use crate::objects::responses::{
-    GraphQLResponse, Page
-};
+use crate::objects::responses::{GraphQLResponse, Page};
 use crate::objects::thread::{Thread, ThreadComment};
 use crate::{client::AniListClient, queries::forum};
 use serde::Serialize;
@@ -133,7 +131,8 @@ impl ForumEndpoint {
         let query = forum::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<Thread>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<Thread>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -141,14 +140,12 @@ impl ForumEndpoint {
     }
 
     /// Fetch a single thread with full details
-    pub async fn fetch_one(
-        &self,
-        options: &FetchThreadOneOptions,
-    ) -> Result<Thread, AniListError> {
+    pub async fn fetch_one(&self, options: &FetchThreadOneOptions) -> Result<Thread, AniListError> {
         let query: &str = forum::FETCH_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Thread>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Thread>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -163,7 +160,8 @@ impl ForumEndpoint {
         let query = forum::FETCH_COMMENT;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<ThreadComment>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<ThreadComment>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -178,7 +176,8 @@ impl ForumEndpoint {
         let query = forum::FETCH_COMMENT_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<ThreadComment>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<ThreadComment>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -186,14 +185,12 @@ impl ForumEndpoint {
     }
 
     /// Create or update a thread
-    pub async fn save(
-        &self,
-        options: &SaveThreadOptions,
-    ) -> Result<Thread, AniListError> {
+    pub async fn save(&self, options: &SaveThreadOptions) -> Result<Thread, AniListError> {
         let query = forum::SAVE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Thread>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Thread>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -201,14 +198,12 @@ impl ForumEndpoint {
     }
 
     /// Delete a thread
-    pub async fn delete(
-        &self,
-        options: &DeleteThreadOptions,
-    ) -> Result<bool, AniListError> {
+    pub async fn delete(&self, options: &DeleteThreadOptions) -> Result<bool, AniListError> {
         let query = forum::DELETE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Deleted>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Deleted>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data.deleted.unwrap_or_default()),
             Err(err) => Err(err),
@@ -223,7 +218,8 @@ impl ForumEndpoint {
         let query = forum::SAVE_COMMENT;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<ThreadComment>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<ThreadComment>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -238,7 +234,8 @@ impl ForumEndpoint {
         let query = forum::DELETE_COMMENT;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Deleted>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Deleted>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data.deleted.unwrap_or_default()),
             Err(err) => Err(err),
@@ -253,7 +250,8 @@ impl ForumEndpoint {
         let query = forum::SUBSCRIPTION;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Thread>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Thread>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -424,10 +422,7 @@ impl ForumEndpoint {
     }
 
     /// Get comment by ID
-    pub async fn get_comment_by_id(
-        &self,
-        id: i32,
-    ) -> Result<ThreadComment, AniListError> {
+    pub async fn get_comment_by_id(&self, id: i32) -> Result<ThreadComment, AniListError> {
         self.fetch_comment_one(&FetchThreadCommentOneOptions { id: Some(id) })
             .await
     }
@@ -479,18 +474,13 @@ impl ForumEndpoint {
     }
 
     /// Delete a comment
-    pub async fn delete_thread_comment(
-        &self,
-        id: i32,
-    ) -> Result<bool, AniListError> {
-        self.delete_comment(&DeleteThreadCommentOptions { id }).await
+    pub async fn delete_thread_comment(&self, id: i32) -> Result<bool, AniListError> {
+        self.delete_comment(&DeleteThreadCommentOptions { id })
+            .await
     }
 
     /// Subscribe to a thread
-    pub async fn subscribe_to_thread(
-        &self,
-        thread_id: i32,
-    ) -> Result<Thread, AniListError> {
+    pub async fn subscribe_to_thread(&self, thread_id: i32) -> Result<Thread, AniListError> {
         self.subscription(&ToggleThreadSubscriptionOptions {
             thread_id,
             subscribe: Some(true),
@@ -499,10 +489,7 @@ impl ForumEndpoint {
     }
 
     /// Unsubscribe from a thread
-    pub async fn unsubscribe_from_thread(
-        &self,
-        thread_id: i32,
-    ) -> Result<Thread, AniListError> {
+    pub async fn unsubscribe_from_thread(&self, thread_id: i32) -> Result<Thread, AniListError> {
         self.subscription(&ToggleThreadSubscriptionOptions {
             thread_id,
             subscribe: Some(false),
@@ -511,10 +498,7 @@ impl ForumEndpoint {
     }
 
     /// Toggle thread subscription
-    pub async fn toggle_thread_subscription(
-        &self,
-        thread_id: i32,
-    ) -> Result<Thread, AniListError> {
+    pub async fn toggle_thread_subscription(&self, thread_id: i32) -> Result<Thread, AniListError> {
         self.subscription(&ToggleThreadSubscriptionOptions {
             thread_id,
             subscribe: None,

--- a/src/endpoints/forum.rs
+++ b/src/endpoints/forum.rs
@@ -8,85 +8,76 @@ use crate::objects::responses::{
 use crate::{client::AniListClient, queries::forum};
 use serde::Serialize;
 use serde_json::json;
+use serde_with::skip_serializing_none;
 
 /// Options for fetching forum threads.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchThreadOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub search: Option<String>,
-    #[serde(rename = "userId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "userId")]
     pub user_id: Option<i32>,
-    #[serde(rename = "replyUserId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "replyUserId")]
     pub reply_user_id: Option<i32>,
-    #[serde(rename = "subscribed", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "subscribed")]
     pub subscribed: Option<bool>,
-    #[serde(rename = "categoryId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "categoryId")]
     pub category_id: Option<i32>,
-    #[serde(rename = "mediaCategoryId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaCategoryId")]
     pub media_category_id: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<ThreadSort>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
 }
 
 /// Options for fetching a single forum thread by ID.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchThreadOneOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(rename = "commentsPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "commentsPage")]
     pub comments_page: Option<i32>,
-    #[serde(rename = "commentsPerPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "commentsPerPage")]
     pub comments_per_page: Option<i32>,
-    #[serde(rename = "commentsSort", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "commentsSort")]
     pub comments_sort: Option<Vec<ThreadCommentSort>>,
 }
 
 /// Options for fetching thread comments.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchThreadCommentOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(rename = "threadId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "threadId")]
     pub thread_id: Option<i32>,
-    #[serde(rename = "userId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "userId")]
     pub user_id: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<ThreadCommentSort>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
 }
 
 /// Options for fetching a single thread comment by ID.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchThreadCommentOneOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
 }
 
 /// Options for creating or updating a forum thread.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct SaveThreadOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub categories: Option<Vec<i32>>,
-    #[serde(rename = "mediaCategories", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaCategories")]
     pub media_categories: Option<Vec<i32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sticky: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub locked: Option<bool>,
 }
 
@@ -97,17 +88,15 @@ pub struct DeleteThreadOptions {
 }
 
 /// Options for creating or updating a thread comment.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct SaveThreadCommentOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(rename = "threadId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "threadId")]
     pub thread_id: Option<i32>,
-    #[serde(rename = "parentCommentId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "parentCommentId")]
     pub parent_comment_id: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub locked: Option<bool>,
 }
 
@@ -118,11 +107,11 @@ pub struct DeleteThreadCommentOptions {
 }
 
 /// Options for subscribing or unsubscribing to a thread.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct ToggleThreadSubscriptionOptions {
     #[serde(rename = "threadId")]
     pub thread_id: i32,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub subscribe: Option<bool>,
 }
 

--- a/src/endpoints/forum.rs
+++ b/src/endpoints/forum.rs
@@ -1,10 +1,10 @@
 use crate::enums::thread::{ThreadCommentSort, ThreadSort};
 use crate::errors::AniListError;
+use crate::objects::common::Deleted;
 use crate::objects::responses::{
-    DeleteThreadCommentResponse, DeleteThreadResponse, SaveThreadCommentResponse,
-    SaveThreadResponse, ThreadCommentListResponse, ThreadCommentSingleResponse, ThreadListResponse,
-    ThreadSingleResponse, ToggleThreadSubscriptionResponse,
+    GraphQLResponse, Page
 };
+use crate::objects::thread::{Thread, ThreadComment};
 use crate::{client::AniListClient, queries::forum};
 use serde::Serialize;
 use serde_json::json;
@@ -12,7 +12,7 @@ use serde_with::skip_serializing_none;
 
 /// Options for fetching forum threads.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchThreadOptions {
     pub id: Option<i32>,
     pub search: Option<String>,
@@ -34,7 +34,7 @@ pub struct FetchThreadOptions {
 
 /// Options for fetching a single forum thread by ID.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchThreadOneOptions {
     pub id: Option<i32>,
     #[serde(rename = "commentsPage")]
@@ -47,7 +47,7 @@ pub struct FetchThreadOneOptions {
 
 /// Options for fetching thread comments.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchThreadCommentOptions {
     pub id: Option<i32>,
     #[serde(rename = "threadId")]
@@ -62,14 +62,14 @@ pub struct FetchThreadCommentOptions {
 
 /// Options for fetching a single thread comment by ID.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchThreadCommentOneOptions {
     pub id: Option<i32>,
 }
 
 /// Options for creating or updating a forum thread.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct SaveThreadOptions {
     pub id: Option<i32>,
     pub title: Option<String>,
@@ -82,14 +82,14 @@ pub struct SaveThreadOptions {
 }
 
 /// Options for deleting a forum thread.
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct DeleteThreadOptions {
     pub id: i32,
 }
 
 /// Options for creating or updating a thread comment.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct SaveThreadCommentOptions {
     pub id: Option<i32>,
     #[serde(rename = "threadId")]
@@ -101,14 +101,14 @@ pub struct SaveThreadCommentOptions {
 }
 
 /// Options for deleting a thread comment.
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct DeleteThreadCommentOptions {
     pub id: i32,
 }
 
 /// Options for subscribing or unsubscribing to a thread.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct ToggleThreadSubscriptionOptions {
     #[serde(rename = "threadId")]
     pub thread_id: i32,
@@ -128,100 +128,136 @@ impl ForumEndpoint {
     /// Fetch multiple threads with pagination
     pub async fn fetch(
         &self,
-        options: FetchThreadOptions,
-    ) -> Result<ThreadListResponse, AniListError> {
+        options: &FetchThreadOptions,
+    ) -> Result<Page<Vec<Thread>>, AniListError> {
         let query = forum::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<Thread>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     /// Fetch a single thread with full details
     pub async fn fetch_one(
         &self,
-        options: FetchThreadOneOptions,
-    ) -> Result<ThreadSingleResponse, AniListError> {
-        let query = forum::FETCH_ONE;
+        options: &FetchThreadOneOptions,
+    ) -> Result<Thread, AniListError> {
+        let query: &str = forum::FETCH_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Thread>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     /// Fetch multiple thread comments with pagination
     pub async fn fetch_comments(
         &self,
-        options: FetchThreadCommentOptions,
-    ) -> Result<ThreadCommentListResponse, AniListError> {
+        options: &FetchThreadCommentOptions,
+    ) -> Result<Page<Vec<ThreadComment>>, AniListError> {
         let query = forum::FETCH_COMMENT;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<ThreadComment>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     /// Fetch a single thread comment
     pub async fn fetch_comment_one(
         &self,
-        options: FetchThreadCommentOneOptions,
-    ) -> Result<ThreadCommentSingleResponse, AniListError> {
+        options: &FetchThreadCommentOneOptions,
+    ) -> Result<ThreadComment, AniListError> {
         let query = forum::FETCH_COMMENT_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<ThreadComment>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     /// Create or update a thread
     pub async fn save(
         &self,
-        options: SaveThreadOptions,
-    ) -> Result<SaveThreadResponse, AniListError> {
+        options: &SaveThreadOptions,
+    ) -> Result<Thread, AniListError> {
         let query = forum::SAVE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Thread>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     /// Delete a thread
     pub async fn delete(
         &self,
-        options: DeleteThreadOptions,
-    ) -> Result<DeleteThreadResponse, AniListError> {
+        options: &DeleteThreadOptions,
+    ) -> Result<bool, AniListError> {
         let query = forum::DELETE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Deleted>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data.deleted.unwrap_or_default()),
+            Err(err) => Err(err),
+        }
     }
 
     /// Create or update a thread comment
     pub async fn save_comment(
         &self,
-        options: SaveThreadCommentOptions,
-    ) -> Result<SaveThreadCommentResponse, AniListError> {
+        options: &SaveThreadCommentOptions,
+    ) -> Result<ThreadComment, AniListError> {
         let query = forum::SAVE_COMMENT;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<ThreadComment>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     /// Delete a thread comment
     pub async fn delete_comment(
         &self,
-        options: DeleteThreadCommentOptions,
-    ) -> Result<DeleteThreadCommentResponse, AniListError> {
+        options: &DeleteThreadCommentOptions,
+    ) -> Result<bool, AniListError> {
         let query = forum::DELETE_COMMENT;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Deleted>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data.deleted.unwrap_or_default()),
+            Err(err) => Err(err),
+        }
     }
 
     /// Toggle thread subscription
     pub async fn subscription(
         &self,
-        options: ToggleThreadSubscriptionOptions,
-    ) -> Result<ToggleThreadSubscriptionResponse, AniListError> {
+        options: &ToggleThreadSubscriptionOptions,
+    ) -> Result<Thread, AniListError> {
         let query = forum::SUBSCRIPTION;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Thread>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     // Convenience functions
@@ -231,8 +267,8 @@ impl ForumEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<ThreadListResponse, AniListError> {
-        self.fetch(FetchThreadOptions {
+    ) -> Result<Page<Vec<Thread>>, AniListError> {
+        self.fetch(&FetchThreadOptions {
             sort: Some(vec![ThreadSort::CreatedAtDesc]),
             page,
             per_page,
@@ -246,8 +282,8 @@ impl ForumEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<ThreadListResponse, AniListError> {
-        self.fetch(FetchThreadOptions {
+    ) -> Result<Page<Vec<Thread>>, AniListError> {
+        self.fetch(&FetchThreadOptions {
             sort: Some(vec![ThreadSort::RepliedAtDesc]),
             page,
             per_page,
@@ -262,8 +298,8 @@ impl ForumEndpoint {
         query: &str,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<ThreadListResponse, AniListError> {
-        self.fetch(FetchThreadOptions {
+    ) -> Result<Page<Vec<Thread>>, AniListError> {
+        self.fetch(&FetchThreadOptions {
             search: Some(query.to_string()),
             sort: Some(vec![ThreadSort::SearchMatch]),
             page,
@@ -279,8 +315,8 @@ impl ForumEndpoint {
         category_id: i32,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<ThreadListResponse, AniListError> {
-        self.fetch(FetchThreadOptions {
+    ) -> Result<Page<Vec<Thread>>, AniListError> {
+        self.fetch(&FetchThreadOptions {
             category_id: Some(category_id),
             sort: Some(vec![ThreadSort::RepliedAtDesc]),
             page,
@@ -296,8 +332,8 @@ impl ForumEndpoint {
         user_id: i32,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<ThreadListResponse, AniListError> {
-        self.fetch(FetchThreadOptions {
+    ) -> Result<Page<Vec<Thread>>, AniListError> {
+        self.fetch(&FetchThreadOptions {
             user_id: Some(user_id),
             sort: Some(vec![ThreadSort::CreatedAtDesc]),
             page,
@@ -312,8 +348,8 @@ impl ForumEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<ThreadListResponse, AniListError> {
-        self.fetch(FetchThreadOptions {
+    ) -> Result<Page<Vec<Thread>>, AniListError> {
+        self.fetch(&FetchThreadOptions {
             subscribed: Some(true),
             sort: Some(vec![ThreadSort::RepliedAtDesc]),
             page,
@@ -324,8 +360,8 @@ impl ForumEndpoint {
     }
 
     /// Get thread by ID
-    pub async fn get_by_id(&self, id: i32) -> Result<ThreadSingleResponse, AniListError> {
-        self.fetch_one(FetchThreadOneOptions {
+    pub async fn get_by_id(&self, id: i32) -> Result<Thread, AniListError> {
+        self.fetch_one(&FetchThreadOneOptions {
             id: Some(id),
             ..Default::default()
         })
@@ -338,8 +374,8 @@ impl ForumEndpoint {
         title: &str,
         body: &str,
         categories: Vec<i32>,
-    ) -> Result<SaveThreadResponse, AniListError> {
-        self.save(SaveThreadOptions {
+    ) -> Result<Thread, AniListError> {
+        self.save(&SaveThreadOptions {
             id: None,
             title: Some(title.to_string()),
             body: Some(body.to_string()),
@@ -355,8 +391,8 @@ impl ForumEndpoint {
         id: i32,
         title: Option<&str>,
         body: Option<&str>,
-    ) -> Result<SaveThreadResponse, AniListError> {
-        self.save(SaveThreadOptions {
+    ) -> Result<Thread, AniListError> {
+        self.save(&SaveThreadOptions {
             id: Some(id),
             title: title.map(|s| s.to_string()),
             body: body.map(|s| s.to_string()),
@@ -366,8 +402,8 @@ impl ForumEndpoint {
     }
 
     /// Delete a thread
-    pub async fn delete_thread(&self, id: i32) -> Result<DeleteThreadResponse, AniListError> {
-        self.delete(DeleteThreadOptions { id }).await
+    pub async fn delete_thread(&self, id: i32) -> Result<bool, AniListError> {
+        self.delete(&DeleteThreadOptions { id }).await
     }
 
     /// Get comments for a thread
@@ -376,8 +412,8 @@ impl ForumEndpoint {
         thread_id: i32,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<ThreadCommentListResponse, AniListError> {
-        self.fetch_comments(FetchThreadCommentOptions {
+    ) -> Result<Page<Vec<ThreadComment>>, AniListError> {
+        self.fetch_comments(&FetchThreadCommentOptions {
             thread_id: Some(thread_id),
             sort: Some(vec![ThreadCommentSort::Id]),
             page,
@@ -391,8 +427,8 @@ impl ForumEndpoint {
     pub async fn get_comment_by_id(
         &self,
         id: i32,
-    ) -> Result<ThreadCommentSingleResponse, AniListError> {
-        self.fetch_comment_one(FetchThreadCommentOneOptions { id: Some(id) })
+    ) -> Result<ThreadComment, AniListError> {
+        self.fetch_comment_one(&FetchThreadCommentOneOptions { id: Some(id) })
             .await
     }
 
@@ -401,8 +437,8 @@ impl ForumEndpoint {
         &self,
         thread_id: i32,
         comment: &str,
-    ) -> Result<SaveThreadCommentResponse, AniListError> {
-        self.save_comment(SaveThreadCommentOptions {
+    ) -> Result<ThreadComment, AniListError> {
+        self.save_comment(&SaveThreadCommentOptions {
             id: None,
             thread_id: Some(thread_id),
             comment: Some(comment.to_string()),
@@ -417,8 +453,8 @@ impl ForumEndpoint {
         thread_id: i32,
         parent_comment_id: i32,
         comment: &str,
-    ) -> Result<SaveThreadCommentResponse, AniListError> {
-        self.save_comment(SaveThreadCommentOptions {
+    ) -> Result<ThreadComment, AniListError> {
+        self.save_comment(&SaveThreadCommentOptions {
             id: None,
             thread_id: Some(thread_id),
             parent_comment_id: Some(parent_comment_id),
@@ -433,8 +469,8 @@ impl ForumEndpoint {
         &self,
         id: i32,
         comment: &str,
-    ) -> Result<SaveThreadCommentResponse, AniListError> {
-        self.save_comment(SaveThreadCommentOptions {
+    ) -> Result<ThreadComment, AniListError> {
+        self.save_comment(&SaveThreadCommentOptions {
             id: Some(id),
             comment: Some(comment.to_string()),
             ..Default::default()
@@ -446,16 +482,16 @@ impl ForumEndpoint {
     pub async fn delete_thread_comment(
         &self,
         id: i32,
-    ) -> Result<DeleteThreadCommentResponse, AniListError> {
-        self.delete_comment(DeleteThreadCommentOptions { id }).await
+    ) -> Result<bool, AniListError> {
+        self.delete_comment(&DeleteThreadCommentOptions { id }).await
     }
 
     /// Subscribe to a thread
     pub async fn subscribe_to_thread(
         &self,
         thread_id: i32,
-    ) -> Result<ToggleThreadSubscriptionResponse, AniListError> {
-        self.subscription(ToggleThreadSubscriptionOptions {
+    ) -> Result<Thread, AniListError> {
+        self.subscription(&ToggleThreadSubscriptionOptions {
             thread_id,
             subscribe: Some(true),
         })
@@ -466,8 +502,8 @@ impl ForumEndpoint {
     pub async fn unsubscribe_from_thread(
         &self,
         thread_id: i32,
-    ) -> Result<ToggleThreadSubscriptionResponse, AniListError> {
-        self.subscription(ToggleThreadSubscriptionOptions {
+    ) -> Result<Thread, AniListError> {
+        self.subscription(&ToggleThreadSubscriptionOptions {
             thread_id,
             subscribe: Some(false),
         })
@@ -478,8 +514,8 @@ impl ForumEndpoint {
     pub async fn toggle_thread_subscription(
         &self,
         thread_id: i32,
-    ) -> Result<ToggleThreadSubscriptionResponse, AniListError> {
-        self.subscription(ToggleThreadSubscriptionOptions {
+    ) -> Result<Thread, AniListError> {
+        self.subscription(&ToggleThreadSubscriptionOptions {
             thread_id,
             subscribe: None,
         })

--- a/src/endpoints/media.rs
+++ b/src/endpoints/media.rs
@@ -4,200 +4,158 @@ use crate::objects::responses::{MediaListResponse, MediaSingleResponse};
 use crate::{client::AniListClient, queries::media};
 use serde::Serialize;
 use serde_json::json;
+use serde_with::skip_serializing_none;
 
 /// Options for fetching media (anime/manga) with various filters.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchMediaOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(rename = "idMal", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "idMal")]
     pub id_mal: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub search: Option<String>,
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type")]
     pub media_type: Option<MediaType>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<MediaFormat>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<MediaStatus>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub season: Option<MediaSeason>,
-    #[serde(rename = "seasonYear", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "seasonYear")]
     pub season_year: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub genre: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tag: Option<String>,
-    #[serde(rename = "tagCategory", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "tagCategory")]
     pub tag_category: Option<String>,
-    #[serde(rename = "minimumTagRank", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "minimumTagRank")]
     pub minimum_tag_rank: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
-    #[serde(rename = "countryOfOrigin", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "countryOfOrigin")]
     pub country_of_origin: Option<String>,
-    #[serde(rename = "isLicensed", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "isLicensed")]
     pub is_licensed: Option<bool>,
-    #[serde(rename = "isAdult", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "isAdult")]
     pub is_adult: Option<bool>,
-    #[serde(rename = "onList", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "onList")]
     pub on_list: Option<bool>,
-    #[serde(rename = "licensedBy", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "licensedBy")]
     pub licensed_by: Option<String>,
-    #[serde(rename = "licensedById", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "licensedById")]
     pub licensed_by_id: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id_not: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id_in: Option<Vec<i32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id_not_in: Option<Vec<i32>>,
-    #[serde(rename = "idMal_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "idMal_not")]
     pub id_mal_not: Option<i32>,
-    #[serde(rename = "idMal_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "idMal_in")]
     pub id_mal_in: Option<Vec<i32>>,
-    #[serde(rename = "idMal_not_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "idMal_not_in")]
     pub id_mal_not_in: Option<Vec<i32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub format_not: Option<MediaFormat>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub format_in: Option<Vec<MediaFormat>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub format_not_in: Option<Vec<MediaFormat>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub status_not: Option<MediaStatus>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub status_in: Option<Vec<MediaStatus>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub status_not_in: Option<Vec<MediaStatus>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub genre_in: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub genre_not_in: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tag_in: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tag_not_in: Option<Vec<String>>,
-    #[serde(rename = "tagCategory_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "tagCategory_in")]
     pub tag_category_in: Option<Vec<String>>,
-    #[serde(rename = "tagCategory_not_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "tagCategory_not_in")]
     pub tag_category_not_in: Option<Vec<String>>,
-    #[serde(rename = "licensedBy_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "licensedBy_in")]
     pub licensed_by_in: Option<Vec<String>>,
-    #[serde(rename = "licensedById_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "licensedById_in")]
     pub licensed_by_id_in: Option<Vec<i32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_in: Option<Vec<String>>,
-    #[serde(rename = "startDate", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "startDate")]
     pub start_date: Option<i32>,
-    #[serde(rename = "endDate", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "endDate")]
     pub end_date: Option<i32>,
-    #[serde(rename = "startDate_greater", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "startDate_greater")]
     pub start_date_greater: Option<i32>,
-    #[serde(rename = "startDate_lesser", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "startDate_lesser")]
     pub start_date_lesser: Option<i32>,
-    #[serde(rename = "startDate_like", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "startDate_like")]
     pub start_date_like: Option<String>,
-    #[serde(rename = "endDate_greater", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "endDate_greater")]
     pub end_date_greater: Option<i32>,
-    #[serde(rename = "endDate_lesser", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "endDate_lesser")]
     pub end_date_lesser: Option<i32>,
-    #[serde(rename = "endDate_like", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "endDate_like")]
     pub end_date_like: Option<String>,
-    #[serde(rename = "averageScore", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "averageScore")]
     pub average_score: Option<i32>,
-    #[serde(rename = "averageScore_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "averageScore_not")]
     pub average_score_not: Option<i32>,
-    #[serde(
-        rename = "averageScore_greater",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "averageScore_greater")]
     pub average_score_greater: Option<i32>,
-    #[serde(
-        rename = "averageScore_lesser",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "averageScore_lesser")]
     pub average_score_lesser: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub popularity: Option<i32>,
-    #[serde(rename = "popularity_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "popularity_not")]
     pub popularity_not: Option<i32>,
-    #[serde(rename = "popularity_greater", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "popularity_greater")]
     pub popularity_greater: Option<i32>,
-    #[serde(rename = "popularity_lesser", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "popularity_lesser")]
     pub popularity_lesser: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub episodes: Option<i32>,
-    #[serde(rename = "episodes_greater", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "episodes_greater")]
     pub episodes_greater: Option<i32>,
-    #[serde(rename = "episodes_lesser", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "episodes_lesser")]
     pub episodes_lesser: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<i32>,
-    #[serde(rename = "duration_greater", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "duration_greater")]
     pub duration_greater: Option<i32>,
-    #[serde(rename = "duration_lesser", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "duration_lesser")]
     pub duration_lesser: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chapters: Option<i32>,
-    #[serde(rename = "chapters_greater", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "chapters_greater")]
     pub chapters_greater: Option<i32>,
-    #[serde(rename = "chapters_lesser", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "chapters_lesser")]
     pub chapters_lesser: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub volumes: Option<i32>,
-    #[serde(rename = "volumes_greater", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "volumes_greater")]
     pub volumes_greater: Option<i32>,
-    #[serde(rename = "volumes_lesser", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "volumes_lesser")]
     pub volumes_lesser: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<MediaSort>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
 }
 
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchMediaOneOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
     // Characters pagination
-    #[serde(rename = "fetchCharacters", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "fetchCharacters")]
     pub fetch_characters: Option<bool>,
-    #[serde(rename = "charactersPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "charactersPage")]
     pub characters_page: Option<i32>,
-    #[serde(rename = "charactersPerPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "charactersPerPage")]
     pub characters_per_page: Option<i32>,
     // Staff pagination
-    #[serde(rename = "fetchStaff", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "fetchStaff")]
     pub fetch_staff: Option<bool>,
-    #[serde(rename = "staffPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "staffPage")]
     pub staff_page: Option<i32>,
-    #[serde(rename = "staffPerPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "staffPerPage")]
     pub staff_per_page: Option<i32>,
     // Reviews pagination
-    #[serde(rename = "fetchReviews", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "fetchReviews")]
     pub fetch_reviews: Option<bool>,
-    #[serde(rename = "reviewsPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "reviewsPage")]
     pub reviews_page: Option<i32>,
-    #[serde(rename = "reviewsPerPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "reviewsPerPage")]
     pub reviews_per_page: Option<i32>,
     // Recommendations pagination
-    #[serde(
-        rename = "fetchRecommendations",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "fetchRecommendations")]
     pub fetch_recommendations: Option<bool>,
-    #[serde(
-        rename = "recommendationsPage",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "recommendationsPage")]
     pub recommendations_page: Option<i32>,
-    #[serde(
-        rename = "recommendationsPerPage",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "recommendationsPerPage")]
     pub recommendations_per_page: Option<i32>,
 }
 

--- a/src/endpoints/media.rs
+++ b/src/endpoints/media.rs
@@ -177,21 +177,20 @@ impl MediaEndpoint {
         let query = media::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<Media>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<Media>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
         }
     }
 
-    pub async fn fetch_one(
-        &self,
-        options: &FetchMediaOneOptions,
-    ) -> Result<Media, AniListError> {
+    pub async fn fetch_one(&self, options: &FetchMediaOneOptions) -> Result<Media, AniListError> {
         let query = media::FETCH_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Media>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Media>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),

--- a/src/endpoints/media.rs
+++ b/src/endpoints/media.rs
@@ -1,6 +1,7 @@
 use crate::enums::media::{MediaFormat, MediaSeason, MediaSort, MediaStatus, MediaType};
 use crate::errors::AniListError;
-use crate::objects::responses::{MediaListResponse, MediaSingleResponse};
+use crate::objects::media::Media;
+use crate::objects::responses::{GraphQLResponse, Page};
 use crate::{client::AniListClient, queries::media};
 use serde::Serialize;
 use serde_json::json;
@@ -8,7 +9,7 @@ use serde_with::skip_serializing_none;
 
 /// Options for fetching media (anime/manga) with various filters.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchMediaOptions {
     pub id: Option<i32>,
     #[serde(rename = "idMal")]
@@ -126,7 +127,7 @@ pub struct FetchMediaOptions {
 }
 
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchMediaOneOptions {
     pub id: Option<i32>,
     // Characters pagination
@@ -171,22 +172,30 @@ impl MediaEndpoint {
 
     pub async fn fetch(
         &self,
-        options: FetchMediaOptions,
-    ) -> Result<MediaListResponse, AniListError> {
+        options: &FetchMediaOptions,
+    ) -> Result<Page<Vec<Media>>, AniListError> {
         let query = media::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<Media>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn fetch_one(
         &self,
-        options: FetchMediaOneOptions,
-    ) -> Result<MediaSingleResponse, AniListError> {
+        options: &FetchMediaOneOptions,
+    ) -> Result<Media, AniListError> {
         let query = media::FETCH_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Media>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     // Convenience functions - Anime
@@ -196,8 +205,8 @@ impl MediaEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<MediaListResponse, AniListError> {
-        self.fetch(FetchMediaOptions {
+    ) -> Result<Page<Vec<Media>>, AniListError> {
+        self.fetch(&FetchMediaOptions {
             media_type: Some(MediaType::Anime),
             sort: Some(vec![MediaSort::PopularityDesc]),
             page,
@@ -212,8 +221,8 @@ impl MediaEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<MediaListResponse, AniListError> {
-        self.fetch(FetchMediaOptions {
+    ) -> Result<Page<Vec<Media>>, AniListError> {
+        self.fetch(&FetchMediaOptions {
             media_type: Some(MediaType::Anime),
             sort: Some(vec![MediaSort::TrendingDesc]),
             page,
@@ -228,8 +237,8 @@ impl MediaEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<MediaListResponse, AniListError> {
-        self.fetch(FetchMediaOptions {
+    ) -> Result<Page<Vec<Media>>, AniListError> {
+        self.fetch(&FetchMediaOptions {
             media_type: Some(MediaType::Anime),
             status: Some(MediaStatus::Releasing),
             sort: Some(vec![MediaSort::PopularityDesc]),
@@ -245,8 +254,8 @@ impl MediaEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<MediaListResponse, AniListError> {
-        self.fetch(FetchMediaOptions {
+    ) -> Result<Page<Vec<Media>>, AniListError> {
+        self.fetch(&FetchMediaOptions {
             media_type: Some(MediaType::Anime),
             status: Some(MediaStatus::NotYetReleased),
             sort: Some(vec![MediaSort::PopularityDesc]),
@@ -264,8 +273,8 @@ impl MediaEndpoint {
         year: i32,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<MediaListResponse, AniListError> {
-        self.fetch(FetchMediaOptions {
+    ) -> Result<Page<Vec<Media>>, AniListError> {
+        self.fetch(&FetchMediaOptions {
             media_type: Some(MediaType::Anime),
             season: Some(season),
             season_year: Some(year),
@@ -283,8 +292,8 @@ impl MediaEndpoint {
         query: &str,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<MediaListResponse, AniListError> {
-        self.fetch(FetchMediaOptions {
+    ) -> Result<Page<Vec<Media>>, AniListError> {
+        self.fetch(&FetchMediaOptions {
             media_type: Some(MediaType::Anime),
             search: Some(query.to_string()),
             sort: Some(vec![MediaSort::SearchMatch]),
@@ -296,8 +305,8 @@ impl MediaEndpoint {
     }
 
     /// Get anime by ID
-    pub async fn get_anime_by_id(&self, id: i32) -> Result<MediaSingleResponse, AniListError> {
-        self.fetch_one(FetchMediaOneOptions {
+    pub async fn get_anime_by_id(&self, id: i32) -> Result<Media, AniListError> {
+        self.fetch_one(&FetchMediaOneOptions {
             id: Some(id),
             ..Default::default()
         })
@@ -309,8 +318,8 @@ impl MediaEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<MediaListResponse, AniListError> {
-        self.fetch(FetchMediaOptions {
+    ) -> Result<Page<Vec<Media>>, AniListError> {
+        self.fetch(&FetchMediaOptions {
             media_type: Some(MediaType::Anime),
             sort: Some(vec![MediaSort::ScoreDesc]),
             page,
@@ -327,8 +336,8 @@ impl MediaEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<MediaListResponse, AniListError> {
-        self.fetch(FetchMediaOptions {
+    ) -> Result<Page<Vec<Media>>, AniListError> {
+        self.fetch(&FetchMediaOptions {
             media_type: Some(MediaType::Manga),
             sort: Some(vec![MediaSort::PopularityDesc]),
             page,
@@ -343,8 +352,8 @@ impl MediaEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<MediaListResponse, AniListError> {
-        self.fetch(FetchMediaOptions {
+    ) -> Result<Page<Vec<Media>>, AniListError> {
+        self.fetch(&FetchMediaOptions {
             media_type: Some(MediaType::Manga),
             sort: Some(vec![MediaSort::TrendingDesc]),
             page,
@@ -359,8 +368,8 @@ impl MediaEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<MediaListResponse, AniListError> {
-        self.fetch(FetchMediaOptions {
+    ) -> Result<Page<Vec<Media>>, AniListError> {
+        self.fetch(&FetchMediaOptions {
             media_type: Some(MediaType::Manga),
             status: Some(MediaStatus::Releasing),
             sort: Some(vec![MediaSort::PopularityDesc]),
@@ -376,8 +385,8 @@ impl MediaEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<MediaListResponse, AniListError> {
-        self.fetch(FetchMediaOptions {
+    ) -> Result<Page<Vec<Media>>, AniListError> {
+        self.fetch(&FetchMediaOptions {
             media_type: Some(MediaType::Manga),
             status: Some(MediaStatus::Finished),
             sort: Some(vec![MediaSort::PopularityDesc]),
@@ -394,8 +403,8 @@ impl MediaEndpoint {
         query: &str,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<MediaListResponse, AniListError> {
-        self.fetch(FetchMediaOptions {
+    ) -> Result<Page<Vec<Media>>, AniListError> {
+        self.fetch(&FetchMediaOptions {
             media_type: Some(MediaType::Manga),
             search: Some(query.to_string()),
             sort: Some(vec![MediaSort::SearchMatch]),
@@ -407,8 +416,8 @@ impl MediaEndpoint {
     }
 
     /// Get manga by ID
-    pub async fn get_manga_by_id(&self, id: i32) -> Result<MediaSingleResponse, AniListError> {
-        self.fetch_one(FetchMediaOneOptions {
+    pub async fn get_manga_by_id(&self, id: i32) -> Result<Media, AniListError> {
+        self.fetch_one(&FetchMediaOneOptions {
             id: Some(id),
             ..Default::default()
         })
@@ -420,8 +429,8 @@ impl MediaEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<MediaListResponse, AniListError> {
-        self.fetch(FetchMediaOptions {
+    ) -> Result<Page<Vec<Media>>, AniListError> {
+        self.fetch(&FetchMediaOptions {
             media_type: Some(MediaType::Manga),
             sort: Some(vec![MediaSort::ScoreDesc]),
             page,

--- a/src/endpoints/media.rs
+++ b/src/endpoints/media.rs
@@ -8,6 +8,25 @@ use serde_json::json;
 use serde_with::skip_serializing_none;
 
 /// Options for fetching media (anime/manga) with various filters.
+///
+/// This struct provides comprehensive filtering and pagination options
+/// for querying anime and manga from the AniList API.
+///
+/// # Examples
+///
+/// ```rust
+/// # use anilist_moe::endpoints::media::FetchMediaOptions;
+/// # use anilist_moe::enums::media::{MediaType, MediaSeason, MediaSort};
+/// let options = FetchMediaOptions {
+///     media_type: Some(MediaType::Anime),
+///     season: Some(MediaSeason::Fall),
+///     season_year: Some(2024),
+///     sort: Some(vec![MediaSort::Popularity]),
+///     page: Some(1),
+///     per_page: Some(20),
+///     ..Default::default()
+/// };
+/// ```
 #[skip_serializing_none]
 #[derive(Default, Debug, Serialize)]
 pub struct FetchMediaOptions {
@@ -126,6 +145,10 @@ pub struct FetchMediaOptions {
     pub per_page: Option<i32>,
 }
 
+/// Options for fetching detailed information about a single media item.
+///
+/// This struct allows fetching a single anime/manga with optional pagination
+/// for related data like characters, staff, reviews, and recommendations.
 #[skip_serializing_none]
 #[derive(Default, Debug, Serialize)]
 pub struct FetchMediaOneOptions {
@@ -161,15 +184,73 @@ pub struct FetchMediaOneOptions {
 }
 
 /// Endpoint for anime and manga operations.
+///
+/// This endpoint provides methods for querying anime and manga data
+/// from the AniList API, including search, filtering, and detailed
+/// information retrieval.
+///
+/// # Examples
+///
+/// ```rust
+/// # use anilist_moe::AniListClient;
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = AniListClient::new();
+///
+/// // Get trending anime
+/// let trending = client.anime().get_trending_anime(Some(1), Some(10)).await?;
+///
+/// // Search for specific anime
+/// let results = client.anime().search_anime("Steins Gate", Some(1), Some(5)).await?;
+///
+/// // Get anime by ID
+/// let anime = client.anime().get_by_id(16498).await?;
+/// # Ok(())
+/// # }
+/// ```
 pub struct MediaEndpoint {
     client: AniListClient,
 }
 
 impl MediaEndpoint {
+    /// Creates a new MediaEndpoint instance.
     pub fn new(client: AniListClient) -> Self {
         Self { client }
     }
 
+    /// Fetches a list of media (anime/manga) with custom options.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Filtering and pagination options
+    ///
+    /// # Returns
+    ///
+    /// Returns `Page<Vec<Media>>` containing the list of media items and pagination info.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use anilist_moe::AniListClient;
+    /// # use anilist_moe::endpoints::media::FetchMediaOptions;
+    /// # use anilist_moe::enums::media::{MediaType, MediaSort};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = AniListClient::new();
+    ///
+    /// let options = FetchMediaOptions {
+    ///     media_type: Some(MediaType::Anime),
+    ///     sort: Some(vec![MediaSort::Popularity]),
+    ///     page: Some(1),
+    ///     per_page: Some(10),
+    ///     ..Default::default()
+    /// };
+    ///
+    /// let response = client.anime().fetch(&options).await?;
+    /// for anime in &response.data {
+    ///     println!("Title: {:?}", anime.title);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn fetch(
         &self,
         options: &FetchMediaOptions,
@@ -185,6 +266,35 @@ impl MediaEndpoint {
         }
     }
 
+    /// Fetches detailed information about a single media item.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Options including the media ID and optional pagination for related data
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Media` object directly (not wrapped in a page structure).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use anilist_moe::AniListClient;
+    /// # use anilist_moe::endpoints::media::FetchMediaOneOptions;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = AniListClient::new();
+    ///
+    /// let options = FetchMediaOneOptions {
+    ///     id: Some(16498), // Attack on Titan
+    ///     ..Default::default()
+    /// };
+    ///
+    /// let anime = client.anime().fetch_one(&options).await?;
+    /// println!("Title: {:?}", anime.title);
+    /// println!("Score: {:?}", anime.average_score);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn fetch_one(&self, options: &FetchMediaOneOptions) -> Result<Media, AniListError> {
         let query = media::FETCH_ONE;
         let variables = json!(options);

--- a/src/endpoints/medialist.rs
+++ b/src/endpoints/medialist.rs
@@ -1,9 +1,10 @@
 use crate::enums::media::MediaType;
 use crate::enums::media_list::{MediaListSort, MediaListStatus};
 use crate::errors::AniListError;
-use crate::objects::common::FuzzyDate;
+use crate::objects::common::{Deleted, FuzzyDate};
+use crate::objects::media_list::MediaList;
 use crate::objects::responses::{
-    DeleteMediaListEntryResponse, SaveMediaListEntryResponse, UserMediaListResponse,
+    GraphQLResponse, Page
 };
 use crate::{client::AniListClient, queries::medialist};
 use serde::Serialize;
@@ -12,7 +13,7 @@ use serde_with::skip_serializing_none;
 
 /// Options for fetching media list entries.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchMediaListOptions {
     #[serde(rename = "userId")]
     pub user_id: Option<i32>,
@@ -66,7 +67,7 @@ pub struct FetchMediaListOptions {
 
 /// Options for creating or updating a media list entry.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SaveMediaListOptions {
     pub id: Option<i32>,
@@ -89,7 +90,7 @@ pub struct SaveMediaListOptions {
 
 /// Options for bulk updating multiple media list entries.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SaveMediaListMultipleOptions {
     pub status: Option<MediaListStatus>,
@@ -109,7 +110,7 @@ pub struct SaveMediaListMultipleOptions {
 }
 
 /// Options for deleting a media list entry.
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct DeleteMediaListOptions {
     pub id: i32,
 }
@@ -126,42 +127,58 @@ impl MediaListEndpoint {
 
     pub async fn fetch(
         &self,
-        options: FetchMediaListOptions,
-    ) -> Result<UserMediaListResponse, AniListError> {
+        options: &FetchMediaListOptions,
+    ) -> Result<Page<Vec<MediaList>>, AniListError> {
         let query = medialist::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<MediaList>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn save(
         &self,
-        options: SaveMediaListOptions,
-    ) -> Result<SaveMediaListEntryResponse, AniListError> {
+        options: &SaveMediaListOptions,
+    ) -> Result<MediaList, AniListError> {
         let query = medialist::SAVE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<MediaList>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn save_multiple(
         &self,
-        options: SaveMediaListMultipleOptions,
-    ) -> Result<Vec<SaveMediaListEntryResponse>, AniListError> {
+        options: &SaveMediaListMultipleOptions,
+    ) -> Result<Vec<MediaList>, AniListError> {
         let query = medialist::SAVE_MULTIPLE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Vec<MediaList>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn delete(
         &self,
-        options: DeleteMediaListOptions,
-    ) -> Result<DeleteMediaListEntryResponse, AniListError> {
+        options: &DeleteMediaListOptions,
+    ) -> Result<bool, AniListError> {
         let query = medialist::DELETE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Deleted>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data.deleted.unwrap_or_default()),
+            Err(err) => Err(err),
+        }
     }
 
     // Convenience functions
@@ -171,12 +188,16 @@ impl MediaListEndpoint {
         &self,
         username: &str,
         status: Option<MediaListStatus>,
-    ) -> Result<UserMediaListResponse, AniListError> {
-        self.fetch(FetchMediaListOptions {
+        page: Option<i32>,
+        per_page: Option<i32>,
+    ) -> Result<Page<Vec<MediaList>>, AniListError> {
+        self.fetch(&FetchMediaListOptions {
             user_name: Some(username.to_string()),
             media_type: Some(MediaType::Anime),
             status,
             sort: Some(vec![MediaListSort::UpdatedTimeDesc]),
+            page,
+            per_page,
             ..Default::default()
         })
         .await
@@ -187,12 +208,16 @@ impl MediaListEndpoint {
         &self,
         username: &str,
         status: Option<MediaListStatus>,
-    ) -> Result<UserMediaListResponse, AniListError> {
-        self.fetch(FetchMediaListOptions {
+        page: Option<i32>,
+        per_page: Option<i32>,
+    ) -> Result<Page<Vec<MediaList>>, AniListError> {
+        self.fetch(&FetchMediaListOptions {
             user_name: Some(username.to_string()),
             media_type: Some(MediaType::Manga),
             status,
             sort: Some(vec![MediaListSort::UpdatedTimeDesc]),
+            page,
+            per_page,
             ..Default::default()
         })
         .await
@@ -202,11 +227,15 @@ impl MediaListEndpoint {
     pub async fn get_my_anime_list(
         &self,
         status: Option<MediaListStatus>,
-    ) -> Result<UserMediaListResponse, AniListError> {
-        self.fetch(FetchMediaListOptions {
+        page: Option<i32>,
+        per_page: Option<i32>,
+    ) -> Result<Page<Vec<MediaList>>, AniListError> {
+        self.fetch(&FetchMediaListOptions {
             media_type: Some(MediaType::Anime),
             status,
             sort: Some(vec![MediaListSort::UpdatedTimeDesc]),
+            page,
+            per_page,
             ..Default::default()
         })
         .await
@@ -216,11 +245,15 @@ impl MediaListEndpoint {
     pub async fn get_my_manga_list(
         &self,
         status: Option<MediaListStatus>,
-    ) -> Result<UserMediaListResponse, AniListError> {
-        self.fetch(FetchMediaListOptions {
+        page: Option<i32>,
+        per_page: Option<i32>,
+    ) -> Result<Page<Vec<MediaList>>, AniListError> {
+        self.fetch(&FetchMediaListOptions {
             media_type: Some(MediaType::Manga),
             status,
             sort: Some(vec![MediaListSort::UpdatedTimeDesc]),
+            page,
+            per_page,
             ..Default::default()
         })
         .await
@@ -230,12 +263,16 @@ impl MediaListEndpoint {
     pub async fn get_watching(
         &self,
         username: Option<&str>,
-    ) -> Result<UserMediaListResponse, AniListError> {
-        self.fetch(FetchMediaListOptions {
+        page: Option<i32>,
+        per_page: Option<i32>,
+    ) -> Result<Page<Vec<MediaList>>, AniListError> {
+        self.fetch(&FetchMediaListOptions {
             user_name: username.map(|s| s.to_string()),
             media_type: Some(MediaType::Anime),
             status: Some(MediaListStatus::Current),
             sort: Some(vec![MediaListSort::UpdatedTimeDesc]),
+            page,
+            per_page,
             ..Default::default()
         })
         .await
@@ -245,12 +282,16 @@ impl MediaListEndpoint {
     pub async fn get_reading(
         &self,
         username: Option<&str>,
-    ) -> Result<UserMediaListResponse, AniListError> {
-        self.fetch(FetchMediaListOptions {
+        page: Option<i32>,
+        per_page: Option<i32>,
+    ) -> Result<Page<Vec<MediaList>>, AniListError> {
+        self.fetch(&FetchMediaListOptions {
             user_name: username.map(|s| s.to_string()),
             media_type: Some(MediaType::Manga),
             status: Some(MediaListStatus::Current),
             sort: Some(vec![MediaListSort::UpdatedTimeDesc]),
+            page,
+            per_page,
             ..Default::default()
         })
         .await
@@ -260,12 +301,16 @@ impl MediaListEndpoint {
     pub async fn get_completed_anime(
         &self,
         username: Option<&str>,
-    ) -> Result<UserMediaListResponse, AniListError> {
-        self.fetch(FetchMediaListOptions {
+        page: Option<i32>,
+        per_page: Option<i32>,
+    ) -> Result<Page<Vec<MediaList>>, AniListError> {
+        self.fetch(&FetchMediaListOptions {
             user_name: username.map(|s| s.to_string()),
             media_type: Some(MediaType::Anime),
             status: Some(MediaListStatus::Completed),
             sort: Some(vec![MediaListSort::ScoreDesc]),
+            page,
+            per_page,
             ..Default::default()
         })
         .await
@@ -275,12 +320,16 @@ impl MediaListEndpoint {
     pub async fn get_completed_manga(
         &self,
         username: Option<&str>,
-    ) -> Result<UserMediaListResponse, AniListError> {
-        self.fetch(FetchMediaListOptions {
+        page: Option<i32>,
+        per_page: Option<i32>,
+    ) -> Result<Page<Vec<MediaList>>, AniListError> {
+        self.fetch(&FetchMediaListOptions {
             user_name: username.map(|s| s.to_string()),
             media_type: Some(MediaType::Manga),
             status: Some(MediaListStatus::Completed),
             sort: Some(vec![MediaListSort::ScoreDesc]),
+            page,
+            per_page,
             ..Default::default()
         })
         .await
@@ -290,12 +339,16 @@ impl MediaListEndpoint {
     pub async fn get_plan_to_watch(
         &self,
         username: Option<&str>,
-    ) -> Result<UserMediaListResponse, AniListError> {
-        self.fetch(FetchMediaListOptions {
+        page: Option<i32>,
+        per_page: Option<i32>,
+    ) -> Result<Page<Vec<MediaList>>, AniListError> {
+        self.fetch(&FetchMediaListOptions {
             user_name: username.map(|s| s.to_string()),
             media_type: Some(MediaType::Anime),
             status: Some(MediaListStatus::Planning),
             sort: Some(vec![MediaListSort::UpdatedTimeDesc]),
+            page,
+            per_page,
             ..Default::default()
         })
         .await
@@ -305,12 +358,16 @@ impl MediaListEndpoint {
     pub async fn get_plan_to_read(
         &self,
         username: Option<&str>,
-    ) -> Result<UserMediaListResponse, AniListError> {
-        self.fetch(FetchMediaListOptions {
+        page: Option<i32>,
+        per_page: Option<i32>,
+    ) -> Result<Page<Vec<MediaList>>, AniListError> {
+        self.fetch(&FetchMediaListOptions {
             user_name: username.map(|s| s.to_string()),
             media_type: Some(MediaType::Manga),
             status: Some(MediaListStatus::Planning),
             sort: Some(vec![MediaListSort::UpdatedTimeDesc]),
+            page,
+            per_page,
             ..Default::default()
         })
         .await
@@ -321,8 +378,8 @@ impl MediaListEndpoint {
         &self,
         media_id: i32,
         status: MediaListStatus,
-    ) -> Result<SaveMediaListEntryResponse, AniListError> {
-        self.save(SaveMediaListOptions {
+    ) -> Result<MediaList, AniListError> {
+        self.save(&SaveMediaListOptions {
             media_id: Some(media_id),
             status: Some(status),
             ..Default::default()
@@ -335,8 +392,8 @@ impl MediaListEndpoint {
         &self,
         media_id: i32,
         status: MediaListStatus,
-    ) -> Result<SaveMediaListEntryResponse, AniListError> {
-        self.save(SaveMediaListOptions {
+    ) -> Result<MediaList, AniListError> {
+        self.save(&SaveMediaListOptions {
             media_id: Some(media_id),
             status: Some(status),
             ..Default::default()
@@ -349,8 +406,8 @@ impl MediaListEndpoint {
         &self,
         entry_id: i32,
         progress: i32,
-    ) -> Result<SaveMediaListEntryResponse, AniListError> {
-        self.save(SaveMediaListOptions {
+    ) -> Result<MediaList, AniListError> {
+        self.save(&SaveMediaListOptions {
             id: Some(entry_id),
             progress: Some(progress),
             ..Default::default()
@@ -363,8 +420,8 @@ impl MediaListEndpoint {
         &self,
         entry_id: i32,
         score: f64,
-    ) -> Result<SaveMediaListEntryResponse, AniListError> {
-        self.save(SaveMediaListOptions {
+    ) -> Result<MediaList, AniListError> {
+        self.save(&SaveMediaListOptions {
             id: Some(entry_id),
             score: Some(score),
             ..Default::default()
@@ -377,8 +434,8 @@ impl MediaListEndpoint {
         &self,
         entry_id: i32,
         status: MediaListStatus,
-    ) -> Result<SaveMediaListEntryResponse, AniListError> {
-        self.save(SaveMediaListOptions {
+    ) -> Result<MediaList, AniListError> {
+        self.save(&SaveMediaListOptions {
             id: Some(entry_id),
             status: Some(status),
             ..Default::default()
@@ -390,7 +447,7 @@ impl MediaListEndpoint {
     pub async fn delete_entry(
         &self,
         entry_id: i32,
-    ) -> Result<DeleteMediaListEntryResponse, AniListError> {
-        self.delete(DeleteMediaListOptions { id: entry_id }).await
+    ) -> Result<bool, AniListError> {
+        self.delete(&DeleteMediaListOptions { id: entry_id }).await
     }
 }

--- a/src/endpoints/medialist.rs
+++ b/src/endpoints/medialist.rs
@@ -3,9 +3,7 @@ use crate::enums::media_list::{MediaListSort, MediaListStatus};
 use crate::errors::AniListError;
 use crate::objects::common::{Deleted, FuzzyDate};
 use crate::objects::media_list::MediaList;
-use crate::objects::responses::{
-    GraphQLResponse, Page
-};
+use crate::objects::responses::{GraphQLResponse, Page};
 use crate::{client::AniListClient, queries::medialist};
 use serde::Serialize;
 use serde_json::json;
@@ -132,21 +130,20 @@ impl MediaListEndpoint {
         let query = medialist::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<MediaList>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<MediaList>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
         }
     }
 
-    pub async fn save(
-        &self,
-        options: &SaveMediaListOptions,
-    ) -> Result<MediaList, AniListError> {
+    pub async fn save(&self, options: &SaveMediaListOptions) -> Result<MediaList, AniListError> {
         let query = medialist::SAVE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<MediaList>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<MediaList>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -160,21 +157,20 @@ impl MediaListEndpoint {
         let query = medialist::SAVE_MULTIPLE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Vec<MediaList>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Vec<MediaList>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
         }
     }
 
-    pub async fn delete(
-        &self,
-        options: &DeleteMediaListOptions,
-    ) -> Result<bool, AniListError> {
+    pub async fn delete(&self, options: &DeleteMediaListOptions) -> Result<bool, AniListError> {
         let query = medialist::DELETE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Deleted>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Deleted>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data.deleted.unwrap_or_default()),
             Err(err) => Err(err),
@@ -416,11 +412,7 @@ impl MediaListEndpoint {
     }
 
     /// Update score for an entry
-    pub async fn update_score(
-        &self,
-        entry_id: i32,
-        score: f64,
-    ) -> Result<MediaList, AniListError> {
+    pub async fn update_score(&self, entry_id: i32, score: f64) -> Result<MediaList, AniListError> {
         self.save(&SaveMediaListOptions {
             id: Some(entry_id),
             score: Some(score),
@@ -444,10 +436,7 @@ impl MediaListEndpoint {
     }
 
     /// Delete a media list entry
-    pub async fn delete_entry(
-        &self,
-        entry_id: i32,
-    ) -> Result<bool, AniListError> {
+    pub async fn delete_entry(&self, entry_id: i32) -> Result<bool, AniListError> {
         self.delete(&DeleteMediaListOptions { id: entry_id }).await
     }
 }

--- a/src/endpoints/notification.rs
+++ b/src/endpoints/notification.rs
@@ -39,7 +39,8 @@ impl NotificationEndpoint {
         let query = notification::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<NotificationUnion>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<NotificationUnion>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),

--- a/src/endpoints/notification.rs
+++ b/src/endpoints/notification.rs
@@ -1,6 +1,7 @@
 use crate::enums::notification::NotificationType;
 use crate::errors::AniListError;
-use crate::objects::responses::NotificationResponse;
+use crate::objects::responses::{GraphQLResponse, Page};
+use crate::unions::notification::NotificationUnion;
 use crate::{client::AniListClient, queries::notification};
 use serde::Serialize;
 use serde_json::json;
@@ -8,7 +9,7 @@ use serde_with::skip_serializing_none;
 
 /// Options for searching and filtering notifications.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct NotificationSearchOptions {
     pub page: Option<i32>,
     #[serde(rename = "perPage")]
@@ -33,15 +34,16 @@ impl NotificationEndpoint {
 
     pub async fn fetch(
         &self,
-        options: NotificationSearchOptions,
-    ) -> Result<NotificationResponse, AniListError> {
+        options: &NotificationSearchOptions,
+    ) -> Result<Page<Vec<NotificationUnion>>, AniListError> {
         let query = notification::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        println!("Variables Map: {:?}", variables_map);
-        let x = self.client.query_typed(query, Some(&variables_map)).await;
-        println!("Query Result: {:?}", x);
-        x
+        let response: Result<GraphQLResponse<Page<Vec<NotificationUnion>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     // Convenience functions
@@ -51,8 +53,8 @@ impl NotificationEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<NotificationResponse, AniListError> {
-        self.fetch(NotificationSearchOptions {
+    ) -> Result<Page<Vec<NotificationUnion>>, AniListError> {
+        self.fetch(&NotificationSearchOptions {
             page,
             per_page,
             ..Default::default()
@@ -65,8 +67,8 @@ impl NotificationEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<NotificationResponse, AniListError> {
-        self.fetch(NotificationSearchOptions {
+    ) -> Result<Page<Vec<NotificationUnion>>, AniListError> {
+        self.fetch(&NotificationSearchOptions {
             page,
             per_page,
             reset_notification_count: Some(true),
@@ -81,8 +83,8 @@ impl NotificationEndpoint {
         notification_type: NotificationType,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<NotificationResponse, AniListError> {
-        self.fetch(NotificationSearchOptions {
+    ) -> Result<Page<Vec<NotificationUnion>>, AniListError> {
+        self.fetch(&NotificationSearchOptions {
             notification_type: Some(notification_type),
             page,
             per_page,

--- a/src/endpoints/notification.rs
+++ b/src/endpoints/notification.rs
@@ -4,22 +4,20 @@ use crate::objects::responses::NotificationResponse;
 use crate::{client::AniListClient, queries::notification};
 use serde::Serialize;
 use serde_json::json;
+use serde_with::skip_serializing_none;
 
 /// Options for searching and filtering notifications.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct NotificationSearchOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type")]
     pub notification_type: Option<NotificationType>,
-    #[serde(rename = "type_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type_in")]
     pub type_in: Option<Vec<NotificationType>>,
-    #[serde(
-        rename = "resetNotificationCount",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "resetNotificationCount")]
     pub reset_notification_count: Option<bool>,
 }
 

--- a/src/endpoints/recommendation.rs
+++ b/src/endpoints/recommendation.rs
@@ -58,7 +58,8 @@ impl RecommendationEndpoint {
         let query = recommendation::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<Recommendation>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<Recommendation>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -72,7 +73,8 @@ impl RecommendationEndpoint {
         let query = recommendation::SAVE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Recommendation>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Recommendation>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),

--- a/src/endpoints/recommendation.rs
+++ b/src/endpoints/recommendation.rs
@@ -1,42 +1,38 @@
 use crate::enums::recommendation::RecommendationSort;
 use crate::errors::AniListError;
-use crate::objects::responses::RecommendationListResponse;
+use crate::objects::recommendation::Recommendation;
+use crate::objects::responses::{GraphQLResponse, Page};
 use crate::{client::AniListClient, queries::recommendation};
 use serde::Serialize;
 use serde_json::json;
+use serde_with::skip_serializing_none;
 
 /// Options for fetching media recommendations.
-#[derive(Default, Serialize)]
+#[skip_serializing_none]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchRecommendationOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(rename = "mediaId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaId")]
     pub media_id: Option<i32>,
-    #[serde(
-        rename = "mediaRecommendationId",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "mediaRecommendationId")]
     pub media_recommendation_id: Option<i32>,
-    #[serde(rename = "userId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "userId")]
     pub user_id: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub rating: Option<i32>,
-    #[serde(rename = "rating_greater", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "rating_greater")]
     pub rating_greater: Option<i32>,
-    #[serde(rename = "rating_lesser", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "rating_lesser")]
     pub rating_lesser: Option<i32>,
-    #[serde(rename = "onList", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "onList")]
     pub on_list: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<RecommendationSort>>,
 }
 
 /// Options for saving a recommendation rating.
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct SaveRecommendationOptions {
     #[serde(rename = "mediaId")]
     pub media_id: i32,
@@ -57,22 +53,30 @@ impl RecommendationEndpoint {
 
     pub async fn fetch(
         &self,
-        options: FetchRecommendationOptions,
-    ) -> Result<RecommendationListResponse, AniListError> {
+        options: &FetchRecommendationOptions,
+    ) -> Result<Page<Vec<Recommendation>>, AniListError> {
         let query = recommendation::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<Recommendation>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn save(
         &self,
-        options: SaveRecommendationOptions,
-    ) -> Result<RecommendationListResponse, AniListError> {
+        options: &SaveRecommendationOptions,
+    ) -> Result<Recommendation, AniListError> {
         let query = recommendation::SAVE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Recommendation>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     // Convenience functions
@@ -83,8 +87,8 @@ impl RecommendationEndpoint {
         media_id: i32,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<RecommendationListResponse, AniListError> {
-        self.fetch(FetchRecommendationOptions {
+    ) -> Result<Page<Vec<Recommendation>>, AniListError> {
+        self.fetch(&FetchRecommendationOptions {
             media_id: Some(media_id),
             page,
             per_page,
@@ -100,8 +104,8 @@ impl RecommendationEndpoint {
         user_id: i32,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<RecommendationListResponse, AniListError> {
-        self.fetch(FetchRecommendationOptions {
+    ) -> Result<Page<Vec<Recommendation>>, AniListError> {
+        self.fetch(&FetchRecommendationOptions {
             user_id: Some(user_id),
             page,
             per_page,
@@ -116,8 +120,8 @@ impl RecommendationEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<RecommendationListResponse, AniListError> {
-        self.fetch(FetchRecommendationOptions {
+    ) -> Result<Page<Vec<Recommendation>>, AniListError> {
+        self.fetch(&FetchRecommendationOptions {
             page,
             per_page,
             sort: Some(vec![RecommendationSort::IdDesc]),
@@ -132,8 +136,8 @@ impl RecommendationEndpoint {
         media_id: i32,
         media_recommendation_id: i32,
         rating: i32,
-    ) -> Result<RecommendationListResponse, AniListError> {
-        self.save(SaveRecommendationOptions {
+    ) -> Result<Recommendation, AniListError> {
+        self.save(&SaveRecommendationOptions {
             media_id,
             media_recommendation_id,
             rating,

--- a/src/endpoints/review.rs
+++ b/src/endpoints/review.rs
@@ -1,7 +1,8 @@
 use crate::enums::media::MediaType;
 use crate::enums::review::ReviewSort;
 use crate::errors::AniListError;
-use crate::objects::responses::{DeleteReviewResponse, GraphQLResponse, Page};
+use crate::objects::common::Deleted;
+use crate::objects::responses::{GraphQLResponse, Page};
 use crate::objects::review::Review;
 use crate::{client::AniListClient, queries::review};
 use serde::Serialize;
@@ -93,10 +94,10 @@ impl ReviewEndpoint {
         let query = review::DELETE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<DeleteReviewResponse, AniListError> =
+        let response: Result<GraphQLResponse<Deleted>, AniListError> =
             self.client.query_typed(query, Some(&variables_map)).await;
         match response {
-            Ok(res) => Ok(res.data.deleted),
+            Ok(res) => Ok(res.data.deleted.unwrap_or_default()),
             Err(err) => Err(err),
         }
     }

--- a/src/endpoints/review.rs
+++ b/src/endpoints/review.rs
@@ -5,40 +5,35 @@ use crate::objects::responses::{ReviewListResponse, ReviewSingleResponse};
 use crate::{client::AniListClient, queries::review};
 use serde::Serialize;
 use serde_json::json;
+use serde_with::skip_serializing_none;
 
 /// Options for fetching reviews.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchReviewOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(rename = "mediaId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaId")]
     pub media_id: Option<i32>,
-    #[serde(rename = "userId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "userId")]
     pub user_id: Option<i32>,
-    #[serde(rename = "mediaType", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaType")]
     pub media_type: Option<MediaType>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<ReviewSort>>,
 }
 
 /// Options for creating or updating a review.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct SaveReviewOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
     #[serde(rename = "mediaId")]
     pub media_id: i32,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub score: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub private: Option<bool>,
 }
 

--- a/src/endpoints/review.rs
+++ b/src/endpoints/review.rs
@@ -1,7 +1,8 @@
 use crate::enums::media::MediaType;
 use crate::enums::review::ReviewSort;
 use crate::errors::AniListError;
-use crate::objects::responses::{ReviewListResponse, ReviewSingleResponse};
+use crate::objects::responses::{DeleteReviewResponse, GraphQLResponse, Page};
+use crate::objects::review::Review;
 use crate::{client::AniListClient, queries::review};
 use serde::Serialize;
 use serde_json::json;
@@ -9,7 +10,7 @@ use serde_with::skip_serializing_none;
 
 /// Options for fetching reviews.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchReviewOptions {
     pub page: Option<i32>,
     #[serde(rename = "perPage")]
@@ -26,7 +27,7 @@ pub struct FetchReviewOptions {
 
 /// Options for creating or updating a review.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct SaveReviewOptions {
     pub id: Option<i32>,
     #[serde(rename = "mediaId")]
@@ -38,13 +39,13 @@ pub struct SaveReviewOptions {
 }
 
 /// Options for deleting a review.
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct DeleteReviewOptions {
     pub id: i32,
 }
 
 /// Options for rating a review.
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct RateReviewOptions {
     #[serde(rename = "reviewId")]
     pub review_id: i32,
@@ -63,42 +64,58 @@ impl ReviewEndpoint {
 
     pub async fn fetch(
         &self,
-        options: FetchReviewOptions,
-    ) -> Result<ReviewListResponse, AniListError> {
+        options: &FetchReviewOptions,
+    ) -> Result<Page<Vec<Review>>, AniListError> {
         let query = review::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<Review>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn save(
         &self,
-        options: SaveReviewOptions,
-    ) -> Result<ReviewSingleResponse, AniListError> {
+        options: &SaveReviewOptions,
+    ) -> Result<Review, AniListError> {
         let query = review::SAVE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Review>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn delete(
         &self,
-        options: DeleteReviewOptions,
-    ) -> Result<ReviewSingleResponse, AniListError> {
+        options: &DeleteReviewOptions,
+    ) -> Result<bool, AniListError> {
         let query = review::DELETE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<DeleteReviewResponse, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data.deleted),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn rate(
         &self,
-        options: RateReviewOptions,
-    ) -> Result<ReviewSingleResponse, AniListError> {
+        options: &RateReviewOptions,
+    ) -> Result<Review, AniListError> {
         let query = review::RATE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Review>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     // Convenience functions
@@ -109,8 +126,8 @@ impl ReviewEndpoint {
         media_id: i32,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<ReviewListResponse, AniListError> {
-        self.fetch(FetchReviewOptions {
+    ) -> Result<Page<Vec<Review>>, AniListError> {
+        self.fetch(&FetchReviewOptions {
             media_id: Some(media_id),
             page,
             per_page,
@@ -126,8 +143,8 @@ impl ReviewEndpoint {
         user_id: i32,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<ReviewListResponse, AniListError> {
-        self.fetch(FetchReviewOptions {
+    ) -> Result<Page<Vec<Review>>, AniListError> {
+        self.fetch(&FetchReviewOptions {
             user_id: Some(user_id),
             page,
             per_page,
@@ -142,8 +159,8 @@ impl ReviewEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<ReviewListResponse, AniListError> {
-        self.fetch(FetchReviewOptions {
+    ) -> Result<Page<Vec<Review>>, AniListError> {
+        self.fetch(&FetchReviewOptions {
             page,
             per_page,
             sort: Some(vec![ReviewSort::CreatedAtDesc]),
@@ -153,12 +170,16 @@ impl ReviewEndpoint {
     }
 
     /// Get review by ID
-    pub async fn get_by_id(&self, id: i32) -> Result<ReviewListResponse, AniListError> {
-        self.fetch(FetchReviewOptions {
+    pub async fn get_by_id(&self, id: i32) -> Result<Review, AniListError> {
+        let response = self.fetch(&FetchReviewOptions {
             id: Some(id),
             ..Default::default()
         })
-        .await
+        .await;
+        match response {
+            Ok(res) => Ok(res.data[0].clone()),
+            Err(err) => Err(err),
+        }
     }
 
     /// Create a new review
@@ -169,8 +190,8 @@ impl ReviewEndpoint {
         summary: &str,
         body: &str,
         private: Option<bool>,
-    ) -> Result<ReviewSingleResponse, AniListError> {
-        self.save(SaveReviewOptions {
+    ) -> Result<Review, AniListError> {
+        self.save(&SaveReviewOptions {
             id: None,
             media_id,
             score: Some(score),
@@ -182,8 +203,8 @@ impl ReviewEndpoint {
     }
 
     /// Delete a review
-    pub async fn delete_review(&self, id: i32) -> Result<ReviewSingleResponse, AniListError> {
-        self.delete(DeleteReviewOptions { id }).await
+    pub async fn delete_review(&self, id: i32) -> Result<bool, AniListError> {
+        self.delete(&DeleteReviewOptions { id }).await
     }
 
     /// Rate a review
@@ -191,7 +212,7 @@ impl ReviewEndpoint {
         &self,
         review_id: i32,
         rating: i32,
-    ) -> Result<ReviewSingleResponse, AniListError> {
-        self.rate(RateReviewOptions { review_id, rating }).await
+    ) -> Result<Review, AniListError> {
+        self.rate(&RateReviewOptions { review_id, rating }).await
     }
 }

--- a/src/endpoints/review.rs
+++ b/src/endpoints/review.rs
@@ -69,49 +69,44 @@ impl ReviewEndpoint {
         let query = review::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<Review>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<Review>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
         }
     }
 
-    pub async fn save(
-        &self,
-        options: &SaveReviewOptions,
-    ) -> Result<Review, AniListError> {
+    pub async fn save(&self, options: &SaveReviewOptions) -> Result<Review, AniListError> {
         let query = review::SAVE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Review>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Review>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
         }
     }
 
-    pub async fn delete(
-        &self,
-        options: &DeleteReviewOptions,
-    ) -> Result<bool, AniListError> {
+    pub async fn delete(&self, options: &DeleteReviewOptions) -> Result<bool, AniListError> {
         let query = review::DELETE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<DeleteReviewResponse, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<DeleteReviewResponse, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data.deleted),
             Err(err) => Err(err),
         }
     }
 
-    pub async fn rate(
-        &self,
-        options: &RateReviewOptions,
-    ) -> Result<Review, AniListError> {
+    pub async fn rate(&self, options: &RateReviewOptions) -> Result<Review, AniListError> {
         let query = review::RATE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Review>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Review>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
@@ -171,11 +166,12 @@ impl ReviewEndpoint {
 
     /// Get review by ID
     pub async fn get_by_id(&self, id: i32) -> Result<Review, AniListError> {
-        let response = self.fetch(&FetchReviewOptions {
-            id: Some(id),
-            ..Default::default()
-        })
-        .await;
+        let response = self
+            .fetch(&FetchReviewOptions {
+                id: Some(id),
+                ..Default::default()
+            })
+            .await;
         match response {
             Ok(res) => Ok(res.data[0].clone()),
             Err(err) => Err(err),
@@ -208,11 +204,7 @@ impl ReviewEndpoint {
     }
 
     /// Rate a review
-    pub async fn rate_review(
-        &self,
-        review_id: i32,
-        rating: i32,
-    ) -> Result<Review, AniListError> {
+    pub async fn rate_review(&self, review_id: i32, rating: i32) -> Result<Review, AniListError> {
         self.rate(&RateReviewOptions { review_id, rating }).await
     }
 }

--- a/src/endpoints/staff.rs
+++ b/src/endpoints/staff.rs
@@ -1,6 +1,7 @@
 use crate::enums::staff::StaffSort;
 use crate::errors::AniListError;
-use crate::objects::responses::{StaffListResponse, StaffSingleResponse};
+use crate::objects::responses::{GraphQLResponse, Page};
+use crate::objects::staff::Staff;
 use crate::{client::AniListClient, queries::staff};
 use serde::Serialize;
 use serde_json::json;
@@ -8,7 +9,7 @@ use serde_with::skip_serializing_none;
 
 /// Options for fetching staff members.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchStaffOptions {
     pub id: Option<i32>,
     #[serde(rename = "isBirthday")]
@@ -21,11 +22,14 @@ pub struct FetchStaffOptions {
     #[serde(rename = "id_not_in")]
     pub id_not_in: Option<Vec<i32>>,
     pub sort: Option<Vec<StaffSort>>,
+    pub page: Option<i32>,
+    #[serde(rename = "perPage")]
+    pub per_page: Option<i32>,
 }
 
 /// Options for fetching a single staff member by ID.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchStaffOneOptions {
     pub id: Option<i32>,
     #[serde(rename = "isBirthday")]
@@ -65,22 +69,30 @@ impl StaffEndpoint {
 
     pub async fn fetch(
         &self,
-        options: FetchStaffOptions,
-    ) -> Result<StaffListResponse, AniListError> {
+        options: &FetchStaffOptions,
+    ) -> Result<Page<Vec<Staff>>, AniListError> {
         let query = staff::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<Staff>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn fetch_one(
         &self,
-        options: FetchStaffOneOptions,
-    ) -> Result<StaffSingleResponse, AniListError> {
+        options: &FetchStaffOneOptions,
+    ) -> Result<Staff, AniListError> {
         let query = staff::FETCH_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Staff>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     // Convenience functions
@@ -88,11 +100,13 @@ impl StaffEndpoint {
     /// Get popular staff sorted by favorites
     pub async fn get_popular(
         &self,
-        _page: Option<i32>,
-        _per_page: Option<i32>,
-    ) -> Result<StaffListResponse, AniListError> {
-        self.fetch(FetchStaffOptions {
+        page: Option<i32>,
+        per_page: Option<i32>,
+    ) -> Result<Page<Vec<Staff>>, AniListError> {
+        self.fetch(&FetchStaffOptions {
             sort: Some(vec![StaffSort::FavouritesDesc]),
+            page,
+            per_page,
             ..Default::default()
         })
         .await
@@ -101,30 +115,32 @@ impl StaffEndpoint {
     /// Get most favorited staff (alias for get_popular)
     pub async fn get_most_favorited(
         &self,
-        _page: Option<i32>,
-        _per_page: Option<i32>,
-    ) -> Result<StaffListResponse, AniListError> {
-        self.get_popular(_page, _per_page).await
+        page: Option<i32>,
+        per_page: Option<i32>,
+    ) -> Result<Page<Vec<Staff>>, AniListError> {
+        self.get_popular(page, per_page).await
     }
 
     /// Search staff by name
     pub async fn search(
         &self,
         query: &str,
-        _page: Option<i32>,
-        _per_page: Option<i32>,
-    ) -> Result<StaffListResponse, AniListError> {
-        self.fetch(FetchStaffOptions {
+        page: Option<i32>,
+        per_page: Option<i32>,
+    ) -> Result<Page<Vec<Staff>>, AniListError> {
+        self.fetch(&FetchStaffOptions {
             search: Some(query.to_string()),
             sort: Some(vec![StaffSort::SearchMatch]),
+            page,
+            per_page,
             ..Default::default()
         })
         .await
     }
 
     /// Get staff by ID
-    pub async fn get_by_id(&self, id: i32) -> Result<StaffSingleResponse, AniListError> {
-        self.fetch_one(FetchStaffOneOptions {
+    pub async fn get_by_id(&self, id: i32) -> Result<Staff, AniListError> {
+        self.fetch_one(&FetchStaffOneOptions {
             id: Some(id),
             ..Default::default()
         })
@@ -134,12 +150,14 @@ impl StaffEndpoint {
     /// Get staff with birthday today
     pub async fn get_today_birthday(
         &self,
-        _page: Option<i32>,
-        _per_page: Option<i32>,
-    ) -> Result<StaffListResponse, AniListError> {
-        self.fetch(FetchStaffOptions {
+        page: Option<i32>,
+        per_page: Option<i32>,
+    ) -> Result<Page<Vec<Staff>>, AniListError> {
+        self.fetch(&FetchStaffOptions {
             is_birthday: Some(true),
             sort: Some(vec![StaffSort::FavouritesDesc]),
+            page,
+            per_page,
             ..Default::default()
         })
         .await

--- a/src/endpoints/staff.rs
+++ b/src/endpoints/staff.rs
@@ -4,58 +4,52 @@ use crate::objects::responses::{StaffListResponse, StaffSingleResponse};
 use crate::{client::AniListClient, queries::staff};
 use serde::Serialize;
 use serde_json::json;
+use serde_with::skip_serializing_none;
 
 /// Options for fetching staff members.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchStaffOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(rename = "isBirthday", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "isBirthday")]
     pub is_birthday: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub search: Option<String>,
-    #[serde(rename = "id_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_not")]
     pub id_not: Option<i32>,
-    #[serde(rename = "id_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_in")]
     pub id_in: Option<Vec<i32>>,
-    #[serde(rename = "id_not_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_not_in")]
     pub id_not_in: Option<Vec<i32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<StaffSort>>,
 }
 
 /// Options for fetching a single staff member by ID.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchStaffOneOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(rename = "isBirthday", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "isBirthday")]
     pub is_birthday: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub search: Option<String>,
-    #[serde(rename = "id_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_not")]
     pub id_not: Option<i32>,
-    #[serde(rename = "id_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_in")]
     pub id_in: Option<Vec<i32>>,
-    #[serde(rename = "id_not_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_not_in")]
     pub id_not_in: Option<Vec<i32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<StaffSort>>,
     // Sub-pagination variables
-    #[serde(rename = "staffMediaPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "staffMediaPage")]
     pub staff_media_page: Option<i32>,
-    #[serde(rename = "staffMediaPerPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "staffMediaPerPage")]
     pub staff_media_per_page: Option<i32>,
-    #[serde(rename = "charactersPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "charactersPage")]
     pub characters_page: Option<i32>,
-    #[serde(rename = "charactersPerPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "charactersPerPage")]
     pub characters_per_page: Option<i32>,
-    #[serde(rename = "characterMediaPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "characterMediaPage")]
     pub character_media_page: Option<i32>,
-    #[serde(
-        rename = "characterMediaPerPage",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "characterMediaPerPage")]
     pub character_media_per_page: Option<i32>,
 }
 

--- a/src/endpoints/staff.rs
+++ b/src/endpoints/staff.rs
@@ -74,21 +74,20 @@ impl StaffEndpoint {
         let query = staff::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<Staff>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<Staff>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
         }
     }
 
-    pub async fn fetch_one(
-        &self,
-        options: &FetchStaffOneOptions,
-    ) -> Result<Staff, AniListError> {
+    pub async fn fetch_one(&self, options: &FetchStaffOneOptions) -> Result<Staff, AniListError> {
         let query = staff::FETCH_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Staff>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Staff>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),

--- a/src/endpoints/studio.rs
+++ b/src/endpoints/studio.rs
@@ -1,6 +1,7 @@
 use crate::enums::studio::StudioSort;
 use crate::errors::AniListError;
-use crate::objects::responses::{StudioListResponse, StudioSingleResponse};
+use crate::objects::responses::{GraphQLResponse, Page};
+use crate::objects::studio::Studio;
 use crate::{client::AniListClient, queries::studio};
 use serde::Serialize;
 use serde_json::json;
@@ -8,7 +9,7 @@ use serde_with::skip_serializing_none;
 
 /// Options for fetching studios.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchStudioOptions {
     pub page: Option<i32>,
     #[serde(rename = "perPage")]
@@ -26,7 +27,7 @@ pub struct FetchStudioOptions {
 
 /// Options for fetching a single studio by ID.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchStudioOneOptions {
     pub id: Option<i32>,
     pub search: Option<String>,
@@ -56,22 +57,30 @@ impl StudioEndpoint {
 
     pub async fn fetch(
         &self,
-        options: FetchStudioOptions,
-    ) -> Result<StudioListResponse, AniListError> {
+        options: &FetchStudioOptions,
+    ) -> Result<Page<Vec<Studio>>, AniListError> {
         let query = studio::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<Studio>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn fetch_one(
         &self,
-        options: FetchStudioOneOptions,
-    ) -> Result<StudioSingleResponse, AniListError> {
+        options: &FetchStudioOneOptions,
+    ) -> Result<Studio, AniListError> {
         let query = studio::FETCH_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Studio>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(err) => Err(err),
+        }
     }
 
     // Convenience functions
@@ -81,8 +90,8 @@ impl StudioEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<StudioListResponse, AniListError> {
-        self.fetch(FetchStudioOptions {
+    ) -> Result<Page<Vec<Studio>>, AniListError> {
+        self.fetch(&FetchStudioOptions {
             page,
             per_page,
             sort: Some(vec![StudioSort::FavouritesDesc]),
@@ -97,8 +106,8 @@ impl StudioEndpoint {
         query: &str,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<StudioListResponse, AniListError> {
-        self.fetch(FetchStudioOptions {
+    ) -> Result<Page<Vec<Studio>>, AniListError> {
+        self.fetch(&FetchStudioOptions {
             search: Some(query.to_string()),
             page,
             per_page,
@@ -109,8 +118,8 @@ impl StudioEndpoint {
     }
 
     /// Get studio by ID
-    pub async fn get_by_id(&self, id: i32) -> Result<StudioSingleResponse, AniListError> {
-        self.fetch_one(FetchStudioOneOptions {
+    pub async fn get_by_id(&self, id: i32) -> Result<Studio, AniListError> {
+        self.fetch_one(&FetchStudioOneOptions {
             id: Some(id),
             ..Default::default()
         })

--- a/src/endpoints/studio.rs
+++ b/src/endpoints/studio.rs
@@ -62,21 +62,20 @@ impl StudioEndpoint {
         let query = studio::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<Studio>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<Studio>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),
         }
     }
 
-    pub async fn fetch_one(
-        &self,
-        options: &FetchStudioOneOptions,
-    ) -> Result<Studio, AniListError> {
+    pub async fn fetch_one(&self, options: &FetchStudioOneOptions) -> Result<Studio, AniListError> {
         let query = studio::FETCH_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Studio>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Studio>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(err) => Err(err),

--- a/src/endpoints/studio.rs
+++ b/src/endpoints/studio.rs
@@ -4,47 +4,43 @@ use crate::objects::responses::{StudioListResponse, StudioSingleResponse};
 use crate::{client::AniListClient, queries::studio};
 use serde::Serialize;
 use serde_json::json;
+use serde_with::skip_serializing_none;
 
 /// Options for fetching studios.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchStudioOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub search: Option<String>,
-    #[serde(rename = "id_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_not")]
     pub id_not: Option<i32>,
-    #[serde(rename = "id_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_in")]
     pub id_in: Option<Vec<i32>>,
-    #[serde(rename = "id_not_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_not_in")]
     pub id_not_in: Option<Vec<i32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<StudioSort>>,
 }
 
 /// Options for fetching a single studio by ID.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchStudioOneOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub search: Option<String>,
-    #[serde(rename = "id_not", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_not")]
     pub id_not: Option<i32>,
-    #[serde(rename = "id_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_in")]
     pub id_in: Option<Vec<i32>>,
-    #[serde(rename = "id_not_in", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "id_not_in")]
     pub id_not_in: Option<Vec<i32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<StudioSort>>,
     // Sub-pagination variables
-    #[serde(rename = "mediaPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaPage")]
     pub media_page: Option<i32>,
-    #[serde(rename = "mediaPerPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mediaPerPage")]
     pub media_per_page: Option<i32>,
 }
 

--- a/src/endpoints/user.rs
+++ b/src/endpoints/user.rs
@@ -2,7 +2,7 @@ use crate::enums::media::{MediaSort, MediaType};
 use crate::enums::media_list::MediaListStatus;
 use crate::enums::user::{UserSort, UserStatisticsSort};
 use crate::errors::AniListError;
-use crate::objects::responses::{GraphQLResponse, Page, ViewerUserData};
+use crate::objects::responses::{GraphQLResponse, Page};
 use crate::objects::user::User;
 use crate::{client::AniListClient, queries::user};
 use serde::Serialize;
@@ -169,9 +169,9 @@ impl UserEndpoint {
     }
 
     /// Fetch basic user information
-    pub async fn fetch_basic(&self) -> Result<ViewerUserData, AniListError> {
+    pub async fn fetch_basic(&self) -> Result<User, AniListError> {
         let query = user::BASIC;
-        let response: Result<GraphQLResponse<ViewerUserData>, AniListError> =
+        let response: Result<GraphQLResponse<User>, AniListError> =
             self.client.query_typed(query, None).await;
         match response {
             Ok(res) => Ok(res.data),

--- a/src/endpoints/user.rs
+++ b/src/endpoints/user.rs
@@ -147,7 +147,8 @@ impl UserEndpoint {
         let query = user::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(e) => Err(e),
@@ -155,14 +156,12 @@ impl UserEndpoint {
     }
 
     /// Fetch a single user with full details
-    pub async fn fetch_one(
-        &self,
-        options: &FetchUserOneOptions,
-    ) -> Result<User, AniListError> {
+    pub async fn fetch_one(&self, options: &FetchUserOneOptions) -> Result<User, AniListError> {
         let query = user::FETCH_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<User>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<User>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(e) => Err(e),
@@ -172,7 +171,8 @@ impl UserEndpoint {
     /// Fetch basic user information
     pub async fn fetch_basic(&self) -> Result<ViewerUserData, AniListError> {
         let query = user::BASIC;
-        let response: Result<GraphQLResponse<ViewerUserData>, AniListError> = self.client.query_typed(query, None).await;
+        let response: Result<GraphQLResponse<ViewerUserData>, AniListError> =
+            self.client.query_typed(query, None).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(e) => Err(e),
@@ -187,7 +187,8 @@ impl UserEndpoint {
         let query = user::FOLLOWERS;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(e) => Err(e),
@@ -202,7 +203,8 @@ impl UserEndpoint {
         let query = user::FOLLOWING;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(e) => Err(e),
@@ -217,7 +219,8 @@ impl UserEndpoint {
         let query = user::FAVORITES;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(e) => Err(e),
@@ -232,7 +235,8 @@ impl UserEndpoint {
         let query = user::MEDIA_LIST;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(e) => Err(e),
@@ -240,14 +244,12 @@ impl UserEndpoint {
     }
 
     /// Fetch user statistics
-    pub async fn stats(
-        &self,
-        options: &FetchUserStatsOptions,
-    ) -> Result<User, AniListError> {
+    pub async fn stats(&self, options: &FetchUserStatsOptions) -> Result<User, AniListError> {
         let query = user::STATS;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        let response: Result<GraphQLResponse<User>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        let response: Result<GraphQLResponse<User>, AniListError> =
+            self.client.query_typed(query, Some(&variables_map)).await;
         match response {
             Ok(res) => Ok(res.data),
             Err(e) => Err(e),

--- a/src/endpoints/user.rs
+++ b/src/endpoints/user.rs
@@ -2,7 +2,8 @@ use crate::enums::media::{MediaSort, MediaType};
 use crate::enums::media_list::MediaListStatus;
 use crate::enums::user::{UserSort, UserStatisticsSort};
 use crate::errors::AniListError;
-use crate::objects::responses::{UserListResponse, UserSingleResponse, ViewerFinalResponse};
+use crate::objects::responses::{GraphQLResponse, Page, ViewerUserData};
+use crate::objects::user::User;
 use crate::{client::AniListClient, queries::user};
 use serde::Serialize;
 use serde_json::json;
@@ -10,7 +11,7 @@ use serde_with::skip_serializing_none;
 
 /// Options for fetching users.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchUserOptions {
     pub id: Option<i32>,
     pub name: Option<String>,
@@ -25,7 +26,7 @@ pub struct FetchUserOptions {
 
 /// Options for fetching a single user by ID or name.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchUserOneOptions {
     pub id: Option<i32>,
     pub name: Option<String>,
@@ -33,7 +34,7 @@ pub struct FetchUserOneOptions {
 
 /// Options for fetching a user's followers.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchUserFollowersOptions {
     #[serde(rename = "userId")]
     pub user_id: i32,
@@ -44,7 +45,7 @@ pub struct FetchUserFollowersOptions {
 
 /// Options for fetching users a user is following.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchUserFollowingOptions {
     #[serde(rename = "userId")]
     pub user_id: i32,
@@ -55,7 +56,7 @@ pub struct FetchUserFollowingOptions {
 
 /// Options for fetching a user's favorites.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchUserFavoritesOptions {
     #[serde(rename = "userId")]
     pub user_id: i32,
@@ -103,7 +104,7 @@ pub struct FetchUserFavoritesOptions {
 
 /// Options for fetching a user's media list.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchUserMediaListOptions {
     #[serde(rename = "userId")]
     pub user_id: Option<i32>,
@@ -124,7 +125,7 @@ pub struct FetchUserMediaListOptions {
 
 /// Options for fetching user statistics.
 #[skip_serializing_none]
-#[derive(Default, Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct FetchUserStatsOptions {
     #[serde(rename = "userId")]
     pub user_id: i32,
@@ -142,92 +143,124 @@ impl UserEndpoint {
     }
 
     /// Fetch multiple users with pagination
-    pub async fn fetch(&self, options: FetchUserOptions) -> Result<UserListResponse, AniListError> {
+    pub async fn fetch(&self, options: FetchUserOptions) -> Result<Page<Vec<User>>, AniListError> {
         let query = user::FETCH;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(e) => Err(e),
+        }
     }
 
     /// Fetch a single user with full details
     pub async fn fetch_one(
         &self,
-        options: FetchUserOneOptions,
-    ) -> Result<UserSingleResponse, AniListError> {
+        options: &FetchUserOneOptions,
+    ) -> Result<User, AniListError> {
         let query = user::FETCH_ONE;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<User>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(e) => Err(e),
+        }
     }
 
     /// Fetch basic user information
-    pub async fn fetch_basic(&self) -> Result<ViewerFinalResponse, AniListError> {
+    pub async fn fetch_basic(&self) -> Result<ViewerUserData, AniListError> {
         let query = user::BASIC;
-        self.client.query_typed(query, None).await
+        let response: Result<GraphQLResponse<ViewerUserData>, AniListError> = self.client.query_typed(query, None).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(e) => Err(e),
+        }
     }
 
     /// Fetch user followers
     pub async fn followers(
         &self,
-        options: FetchUserFollowersOptions,
-    ) -> Result<UserListResponse, AniListError> {
+        options: &FetchUserFollowersOptions,
+    ) -> Result<Page<Vec<User>>, AniListError> {
         let query = user::FOLLOWERS;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(e) => Err(e),
+        }
     }
 
     /// Fetch users that the user is following
     pub async fn following(
         &self,
-        options: FetchUserFollowingOptions,
-    ) -> Result<UserListResponse, AniListError> {
+        options: &FetchUserFollowingOptions,
+    ) -> Result<Page<Vec<User>>, AniListError> {
         let query = user::FOLLOWING;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(e) => Err(e),
+        }
     }
 
     /// Fetch user favorites with conditional sections and independent pagination
     pub async fn favorites(
         &self,
-        options: FetchUserFavoritesOptions,
-    ) -> Result<UserSingleResponse, AniListError> {
+        options: &FetchUserFavoritesOptions,
+    ) -> Result<Page<Vec<User>>, AniListError> {
         let query = user::FAVORITES;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(e) => Err(e),
+        }
     }
 
     /// Fetch user's media list
     pub async fn media_list(
         &self,
-        options: FetchUserMediaListOptions,
-    ) -> Result<UserListResponse, AniListError> {
+        options: &FetchUserMediaListOptions,
+    ) -> Result<Page<Vec<User>>, AniListError> {
         let query = user::MEDIA_LIST;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<Page<Vec<User>>>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(e) => Err(e),
+        }
     }
 
     /// Fetch user statistics
     pub async fn stats(
         &self,
-        options: FetchUserStatsOptions,
-    ) -> Result<UserSingleResponse, AniListError> {
+        options: &FetchUserStatsOptions,
+    ) -> Result<User, AniListError> {
         let query = user::STATS;
         let variables = json!(options);
         let variables_map = crate::utils::json_to_hashmap(variables);
-        self.client.query_typed(query, Some(&variables_map)).await
+        let response: Result<GraphQLResponse<User>, AniListError> = self.client.query_typed(query, Some(&variables_map)).await;
+        match response {
+            Ok(res) => Ok(res.data),
+            Err(e) => Err(e),
+        }
     }
 
     // Convenience functions
 
     /// Get current authenticated user
-    pub async fn get_current_user(&self) -> Result<UserSingleResponse, AniListError> {
+    pub async fn get_current_user(&self) -> Result<User, AniListError> {
         let response = self.client.user().fetch_basic().await?;
-        let id = response.data.viewer.id;
-        self.fetch_one(FetchUserOneOptions {
+        let id = response.id;
+        self.fetch_one(&FetchUserOneOptions {
             id: Some(id),
             ..Default::default()
         })
@@ -235,8 +268,8 @@ impl UserEndpoint {
     }
 
     /// Get user by ID
-    pub async fn get_by_id(&self, id: i32) -> Result<UserSingleResponse, AniListError> {
-        self.fetch_one(FetchUserOneOptions {
+    pub async fn get_by_id(&self, id: i32) -> Result<User, AniListError> {
+        self.fetch_one(&FetchUserOneOptions {
             id: Some(id),
             ..Default::default()
         })
@@ -244,8 +277,8 @@ impl UserEndpoint {
     }
 
     /// Get user by username
-    pub async fn get_by_name(&self, name: &str) -> Result<UserSingleResponse, AniListError> {
-        self.fetch_one(FetchUserOneOptions {
+    pub async fn get_by_name(&self, name: &str) -> Result<User, AniListError> {
+        self.fetch_one(&FetchUserOneOptions {
             name: Some(name.to_string()),
             ..Default::default()
         })
@@ -258,7 +291,7 @@ impl UserEndpoint {
         query: &str,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<UserListResponse, AniListError> {
+    ) -> Result<Page<Vec<User>>, AniListError> {
         self.fetch(FetchUserOptions {
             search: Some(query.to_string()),
             page,
@@ -274,7 +307,7 @@ impl UserEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<UserListResponse, AniListError> {
+    ) -> Result<Page<Vec<User>>, AniListError> {
         self.fetch(FetchUserOptions {
             page,
             per_page,
@@ -289,7 +322,7 @@ impl UserEndpoint {
         &self,
         page: Option<i32>,
         per_page: Option<i32>,
-    ) -> Result<UserListResponse, AniListError> {
+    ) -> Result<Page<Vec<User>>, AniListError> {
         self.fetch(FetchUserOptions {
             page,
             per_page,

--- a/src/endpoints/user.rs
+++ b/src/endpoints/user.rs
@@ -6,135 +6,128 @@ use crate::objects::responses::{UserListResponse, UserSingleResponse, ViewerFina
 use crate::{client::AniListClient, queries::user};
 use serde::Serialize;
 use serde_json::json;
+use serde_with::skip_serializing_none;
 
 /// Options for fetching users.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchUserOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub search: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<UserSort>>,
-    #[serde(rename = "isModerator", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "isModerator")]
     pub is_moderator: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
 }
 
 /// Options for fetching a single user by ID or name.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchUserOneOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 /// Options for fetching a user's followers.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchUserFollowersOptions {
     #[serde(rename = "userId")]
     pub user_id: i32,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
 }
 
 /// Options for fetching users a user is following.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchUserFollowingOptions {
     #[serde(rename = "userId")]
     pub user_id: i32,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
 }
 
 /// Options for fetching a user's favorites.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchUserFavoritesOptions {
     #[serde(rename = "userId")]
     pub user_id: i32,
     // Toggle what to fetch
-    #[serde(rename = "fetchAnime", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "fetchAnime")]
     pub fetch_anime: Option<bool>,
-    #[serde(rename = "fetchManga", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "fetchManga")]
     pub fetch_manga: Option<bool>,
-    #[serde(rename = "fetchCharacters", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "fetchCharacters")]
     pub fetch_characters: Option<bool>,
-    #[serde(rename = "fetchStaff", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "fetchStaff")]
     pub fetch_staff: Option<bool>,
-    #[serde(rename = "fetchStudios", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "fetchStudios")]
     pub fetch_studios: Option<bool>,
     // Anime pagination
-    #[serde(rename = "animePage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "animePage")]
     pub anime_page: Option<i32>,
-    #[serde(rename = "animePerPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "animePerPage")]
     pub anime_per_page: Option<i32>,
-    #[serde(rename = "animeSort", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "animeSort")]
     pub anime_sort: Option<Vec<MediaSort>>,
     // Manga pagination
-    #[serde(rename = "mangaPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mangaPage")]
     pub manga_page: Option<i32>,
-    #[serde(rename = "mangaPerPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mangaPerPage")]
     pub manga_per_page: Option<i32>,
-    #[serde(rename = "mangaSort", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mangaSort")]
     pub manga_sort: Option<Vec<MediaSort>>,
     // Characters pagination
-    #[serde(rename = "charactersPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "charactersPage")]
     pub characters_page: Option<i32>,
-    #[serde(rename = "charactersPerPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "charactersPerPage")]
     pub characters_per_page: Option<i32>,
     // Staff pagination
-    #[serde(rename = "staffPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "staffPage")]
     pub staff_page: Option<i32>,
-    #[serde(rename = "staffPerPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "staffPerPage")]
     pub staff_per_page: Option<i32>,
     // Studios pagination
-    #[serde(rename = "studiosPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "studiosPage")]
     pub studios_page: Option<i32>,
-    #[serde(rename = "studiosPerPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "studiosPerPage")]
     pub studios_per_page: Option<i32>,
 }
 
 /// Options for fetching a user's media list.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchUserMediaListOptions {
-    #[serde(rename = "userId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "userId")]
     pub user_id: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type")]
     pub media_type: Option<MediaType>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<MediaListStatus>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub notes: Option<String>,
-    #[serde(rename = "startedAt", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "startedAt")]
     pub started_at: Option<i32>,
-    #[serde(rename = "completedAt", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "completedAt")]
     pub completed_at: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<MediaSort>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub page: Option<i32>,
-    #[serde(rename = "perPage", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "perPage")]
     pub per_page: Option<i32>,
 }
 
 /// Options for fetching user statistics.
+#[skip_serializing_none]
 #[derive(Default, Serialize)]
 pub struct FetchUserStatsOptions {
     #[serde(rename = "userId")]
     pub user_id: i32,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<UserStatisticsSort>>,
 }
 

--- a/src/endpoints/user.rs
+++ b/src/endpoints/user.rs
@@ -2,7 +2,7 @@ use crate::enums::media::{MediaSort, MediaType};
 use crate::enums::media_list::MediaListStatus;
 use crate::enums::user::{UserSort, UserStatisticsSort};
 use crate::errors::AniListError;
-use crate::objects::responses::{UserListResponse, UserSingleResponse};
+use crate::objects::responses::{UserListResponse, UserSingleResponse, ViewerFinalResponse};
 use crate::{client::AniListClient, queries::user};
 use serde::Serialize;
 use serde_json::json;
@@ -168,7 +168,7 @@ impl UserEndpoint {
     }
 
     /// Fetch basic user information
-    pub async fn fetch_basic(&self) -> Result<UserSingleResponse, AniListError> {
+    pub async fn fetch_basic(&self) -> Result<ViewerFinalResponse, AniListError> {
         let query = user::BASIC;
         self.client.query_typed(query, None).await
     }
@@ -233,7 +233,7 @@ impl UserEndpoint {
     /// Get current authenticated user
     pub async fn get_current_user(&self) -> Result<UserSingleResponse, AniListError> {
         let response = self.client.user().fetch_basic().await?;
-        let id = response.data.user.id;
+        let id = response.data.viewer.id;
         self.fetch_one(FetchUserOneOptions {
             id: Some(id),
             ..Default::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Example usage
     let popular_anime = client
         .media()
-        .fetch(FetchMediaOptions {
+        .fetch(&FetchMediaOptions {
             sort: Some(vec![anilist_moe::enums::media::MediaSort::PopularityDesc]),
             per_page: Some(5),
             page: Some(1),

--- a/src/objects/activity.rs
+++ b/src/objects/activity.rs
@@ -51,7 +51,7 @@ pub struct ListActivity {
     #[serde(rename = "type")]
     pub activity_type: Option<ActivityType>,
     pub reply_count: Option<i32>,
-    status: Option<String>,
+    pub status: Option<String>,
     pub progress: Option<String>,
     pub is_locked: Option<bool>,
     pub is_subscribed: Option<bool>,

--- a/src/objects/media.rs
+++ b/src/objects/media.rs
@@ -141,11 +141,11 @@ pub struct MediaEdge {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MediaExternalLink {
-    id: i32,
-    url: Option<String>,
-    site: Option<String>,
-    site_id: Option<i32>,
-    link_type: Option<ExternalLinkType>,
+    pub id: i32,
+    pub url: Option<String>,
+    pub site: Option<String>,
+    pub site_id: Option<i32>,
+    pub link_type: Option<ExternalLinkType>,
     pub language: Option<String>,
     pub color: Option<String>,
     pub icon: Option<String>,

--- a/src/objects/media.rs
+++ b/src/objects/media.rs
@@ -103,9 +103,9 @@ pub struct MediaCharacter {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MediaConnection {
-    edges: Option<Vec<MediaEdge>>,
-    nodes: Option<Vec<Media>>,
-    page_info: Option<PageInfo>,
+    pub edges: Option<Vec<MediaEdge>>,
+    pub nodes: Option<Vec<Media>>,
+    pub page_info: Option<PageInfo>,
 }
 
 #[skip_serializing_none]
@@ -122,9 +122,9 @@ pub struct MediaCoverImage {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MediaEdge {
-    node: Option<Media>,
-    id: Option<i32>,
-    relation_type: Option<MediaRelation>,
+    pub node: Option<Media>,
+    pub id: Option<i32>,
+    pub relation_type: Option<MediaRelation>,
     pub is_main_studio: Option<bool>,
     pub characters: Option<Vec<Character>>,
     pub character_role: Option<CharacterRole>,

--- a/src/objects/responses.rs
+++ b/src/objects/responses.rs
@@ -15,11 +15,11 @@ use crate::objects::user::{User, UserAvatar};
 use crate::unions::activity::ActivityUnion;
 use crate::unions::likeable::LikeableUnion;
 use crate::unions::notification::NotificationUnion;
-use serde::{Deserialize, Serialize};
 use serde::de::{self, Deserializer, MapAccess, Visitor};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::fmt;
 use std::marker::PhantomData;
-use serde_with::skip_serializing_none;
 
 /// Top-level GraphQL response wrapper
 #[skip_serializing_none]
@@ -345,7 +345,6 @@ pub struct DeleteActivityData {
     pub deleted: DeletedResponse,
 }
 
-
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -454,9 +453,6 @@ pub type SaveThreadCommentResponse = GraphQLResponse<SaveThreadCommentData>;
 pub type DeleteThreadCommentResponse = GraphQLResponse<DeleteThreadCommentData>;
 pub type ToggleThreadSubscriptionResponse = GraphQLResponse<ToggleThreadSubscriptionData>;
 
-
-
-
 // The high-performance custom deserialization logic
 impl<'de, T> Deserialize<'de> for Page<T>
 where
@@ -554,8 +550,9 @@ where
                 A: MapAccess<'de>,
             {
                 // 1. Ignore the key of the single inner field.
-                map.next_key::<de::IgnoredAny>()?
-                    .ok_or_else(|| de::Error::custom("expected a single data field, but the object was empty"))?;
+                map.next_key::<de::IgnoredAny>()?.ok_or_else(|| {
+                    de::Error::custom("expected a single data field, but the object was empty")
+                })?;
 
                 // 2. Deserialize the value directly into our final T.
                 let data: T = map.next_value()?;
@@ -594,10 +591,14 @@ where
                 A: MapAccess<'de>,
             {
                 // 1. Expect the outer key to be "data".
-                let key = map.next_key::<String>()?
-                    .ok_or_else(|| de::Error::custom("expected field 'data', but object was empty"))?;
+                let key = map.next_key::<String>()?.ok_or_else(|| {
+                    de::Error::custom("expected field 'data', but object was empty")
+                })?;
                 if key != "data" {
-                    return Err(de::Error::invalid_value(de::Unexpected::Str(&key), &"the field 'data'"));
+                    return Err(de::Error::invalid_value(
+                        de::Unexpected::Str(&key),
+                        &"the field 'data'",
+                    ));
                 }
 
                 // 2. Deserialize the value using the custom logic we defined for InnerData.

--- a/src/objects/responses.rs
+++ b/src/objects/responses.rs
@@ -8,9 +8,10 @@ use crate::objects::media_list::MediaList;
 use crate::objects::recommendation::Recommendation;
 use crate::objects::review::Review;
 use crate::objects::staff::Staff;
+use crate::objects::stats::UserStatisticTypes;
 use crate::objects::studio::Studio;
 use crate::objects::thread::{Thread, ThreadComment};
-use crate::objects::user::User;
+use crate::objects::user::{User, UserAvatar};
 use crate::unions::activity::ActivityUnion;
 use crate::unions::likeable::LikeableUnion;
 use crate::unions::notification::NotificationUnion;
@@ -285,9 +286,11 @@ pub struct ToggleThreadSubscriptionData {
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ViewerUnreadCount {
+pub struct ViewerUserData {
     pub id: i32,
     pub name: String,
+    pub avatar: Option<UserAvatar>,
+    pub statistics: Option<UserStatisticTypes>,
     pub unread_notification_count: i32,
 }
 
@@ -305,7 +308,7 @@ pub type AiringListResponse = GraphQLResponse<PageResponse<AiringData>>;
 pub type AiringSingleResponse = GraphQLResponse<AiringScheduleResponse>;
 pub type RecommendationListResponse = GraphQLResponse<PageResponse<RecommendationData>>;
 pub type ReviewListResponse = GraphQLResponse<PageResponse<ReviewData>>;
-pub type UnreadCountResponse = GraphQLResponse<ViewerResponse<ViewerUnreadCount>>;
+pub type ViewerFinalResponse = GraphQLResponse<ViewerResponse<ViewerUserData>>;
 
 // Single item response types
 pub type MediaSingleResponse = GraphQLResponse<MediaResponse>;

--- a/src/objects/responses.rs
+++ b/src/objects/responses.rs
@@ -1,27 +1,23 @@
-use crate::objects::activity::{ActivityReply, MessageActivity, TextActivity};
-use crate::objects::airing::AiringSchedule;
-use crate::objects::character::Character;
 use crate::objects::common::PageInfo;
-use crate::objects::favourites::Favourites;
-use crate::objects::media::Media;
-use crate::objects::media_list::MediaList;
-use crate::objects::recommendation::Recommendation;
-use crate::objects::review::Review;
-use crate::objects::staff::Staff;
-use crate::objects::stats::UserStatisticTypes;
-use crate::objects::studio::Studio;
-use crate::objects::thread::{Thread, ThreadComment};
-use crate::objects::user::{User, UserAvatar};
-use crate::unions::activity::ActivityUnion;
-use crate::unions::likeable::LikeableUnion;
-use crate::unions::notification::NotificationUnion;
 use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::fmt;
 use std::marker::PhantomData;
 
-/// Top-level GraphQL response wrapper
+/// Top-level GraphQL response wrapper.
+///
+/// This struct wraps all responses from the AniList GraphQL API.
+/// The generic type `T` represents the actual data returned by the query.
+///
+/// # Type Parameters
+///
+/// * `T` - The type of data contained in the response
+///
+/// # Notes
+///
+/// This wrapper is handled internally by the client and is transparent
+/// to users in most cases. Endpoint methods return the inner `T` directly.
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -29,429 +25,52 @@ pub struct GraphQLResponse<T> {
     pub data: T,
 }
 
-/// Generic response wrapper for paginated data
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PageResponse<T> {
-    #[serde(rename = "Page")]
-    pub page: Page<T>,
-}
-
-/// Generic page structure
+/// Pagination wrapper for list responses.
+///
+/// This struct wraps paginated list responses from the AniList API.
+/// It contains pagination metadata and the actual data list.
+///
+/// # Type Parameters
+///
+/// * `T` - The type of data list (typically `Vec<SomeType>`)
+///
+/// # Fields
+///
+/// * `page_info` - Optional pagination metadata (current page, total, has_next_page, etc.)
+/// * `data` - The actual list of items returned by the query
+///
+/// # Examples
+///
+/// ```rust
+/// # use anilist_moe::AniListClient;
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = AniListClient::new();
+///
+/// // Returns Page<Vec<Media>>
+/// let response = client.anime().get_trending_anime(Some(1), Some(10)).await?;
+///
+/// // Access the Vec<Media> through response.data
+/// for anime in &response.data {
+///     println!("Title: {:?}", anime.title);
+/// }
+///
+/// // Access pagination info
+/// if let Some(page_info) = &response.page_info {
+///     println!("Current page: {:?}", page_info.current_page);
+///     println!("Has next page: {:?}", page_info.has_next_page);
+/// }
+/// # Ok(())
+/// # }
+/// ```
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Page<T> {
+    /// Pagination metadata including current page, total items, and whether there are more pages
     pub page_info: Option<PageInfo>,
+    /// The list of items for this page
     pub data: T,
 }
-
-/// Generic viewer response wrapper
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ViewerResponse<T> {
-    #[serde(rename = "Viewer")]
-    pub viewer: T,
-}
-
-/// Specific response data types
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NotificationData {
-    pub notifications: Vec<NotificationUnion>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MediaData {
-    pub media: Vec<Media>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MediaListData {
-    pub media_list: Vec<MediaList>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CharacterData {
-    pub characters: Vec<Character>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StaffData {
-    pub staff: Vec<Staff>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StudioData {
-    pub studios: Vec<Studio>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct UserData {
-    pub users: Vec<User>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ActivityData {
-    pub activities: Vec<ActivityUnion>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ActivityReplyData {
-    pub activity_replies: Vec<ActivityReply>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AiringData {
-    pub airing_schedules: Vec<AiringSchedule>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AiringScheduleResponse {
-    #[serde(rename = "AiringSchedule")]
-    pub airing_schedule: AiringSchedule,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RecommendationData {
-    pub recommendations: Vec<Recommendation>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ReviewData {
-    pub reviews: Vec<Review>,
-}
-
-/// Single item response wrappers
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MediaResponse {
-    #[serde(rename = "Media")]
-    pub media: Media,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CharacterResponse {
-    #[serde(rename = "Character")]
-    pub character: Character,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StaffResponse {
-    #[serde(rename = "Staff")]
-    pub staff: Staff,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct StudioResponse {
-    #[serde(rename = "Studio")]
-    pub studio: Studio,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct UserResponse {
-    #[serde(rename = "User")]
-    pub user: User,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ActivityResponse {
-    #[serde(rename = "Activity")]
-    pub activity: ActivityUnion,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ReviewResponse {
-    #[serde(rename = "Review")]
-    pub review: Review,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RecommendationResponse {
-    #[serde(rename = "Recommendation")]
-    pub recommendation: Recommendation,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ThreadData {
-    pub threads: Vec<Thread>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ThreadResponse {
-    #[serde(rename = "Thread")]
-    pub thread: Thread,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ThreadCommentData {
-    pub thread_comments: Vec<ThreadComment>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ThreadCommentResponse {
-    #[serde(rename = "ThreadComment")]
-    pub thread_comment: ThreadComment,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SaveThreadData {
-    #[serde(rename = "SaveThread")]
-    pub save_thread: Thread,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DeleteThreadData {
-    #[serde(rename = "DeleteThread")]
-    pub deleted: DeletedResponse,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SaveThreadCommentData {
-    #[serde(rename = "SaveThreadComment")]
-    pub save_thread_comment: ThreadComment,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DeleteThreadCommentData {
-    #[serde(rename = "DeleteThreadComment")]
-    pub deleted: DeletedResponse,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ToggleThreadSubscriptionData {
-    #[serde(rename = "ToggleThreadSubscription")]
-    pub toggle_thread_subscription: Thread,
-}
-
-/// Viewer-specific response data types
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ViewerUserData {
-    pub id: i32,
-    pub name: String,
-    pub avatar: Option<UserAvatar>,
-    pub statistics: Option<UserStatisticTypes>,
-    pub unread_notification_count: i32,
-}
-
-/// Type aliases for common response patterns
-pub type NotificationResponse = GraphQLResponse<Page<Vec<NotificationUnion>>>;
-pub type UserMediaListResponse = GraphQLResponse<Page<Vec<MediaList>>>;
-pub type CharacterListResponse = GraphQLResponse<Page<Vec<Character>>>;
-pub type StaffListResponse = GraphQLResponse<Page<Vec<Staff>>>;
-pub type StudioListResponse = GraphQLResponse<Page<Vec<Studio>>>;
-pub type UserListResponse = GraphQLResponse<Page<Vec<User>>>;
-pub type ActivityListResponse = GraphQLResponse<Page<Vec<ActivityUnion>>>;
-pub type ActivityReplyListResponse = GraphQLResponse<Page<Vec<ActivityReply>>>;
-pub type AiringListResponse = GraphQLResponse<Page<Vec<AiringSchedule>>>;
-pub type AiringSingleResponse = GraphQLResponse<AiringScheduleResponse>;
-pub type RecommendationListResponse = GraphQLResponse<Page<Vec<Recommendation>>>;
-pub type ReviewListResponse = GraphQLResponse<Page<Vec<Review>>>;
-pub type ViewerFinalResponse = GraphQLResponse<ViewerResponse<ViewerUserData>>;
-
-// Single item response types
-pub type CharacterSingleResponse = GraphQLResponse<Character>;
-pub type StaffSingleResponse = GraphQLResponse<Staff>;
-pub type StudioSingleResponse = GraphQLResponse<Studio>;
-pub type UserSingleResponse = GraphQLResponse<User>;
-pub type ActivitySingleResponse = GraphQLResponse<ActivityUnion>;
-pub type ReviewSingleResponse = GraphQLResponse<Review>;
-pub type RecommendationSingleResponse = GraphQLResponse<Recommendation>;
-
-// Activity mutation response types
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SaveTextActivityData {
-    #[serde(rename = "SaveTextActivity")]
-    pub save_text_activity: TextActivity,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SaveMessageActivityData {
-    #[serde(rename = "SaveMessageActivity")]
-    pub save_message_activity: MessageActivity,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DeleteActivityData {
-    #[serde(rename = "DeleteActivity")]
-    pub deleted: DeletedResponse,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DeleteReviewData {
-    #[serde(rename = "DeleteReview")]
-    pub deleted: bool,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DeletedResponse {
-    pub deleted: bool,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SaveActivityReplyData {
-    #[serde(rename = "SaveActivityReply")]
-    pub save_activity_reply: ActivityReply,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DeleteActivityReplyData {
-    #[serde(rename = "DeleteActivityReply")]
-    pub deleted: DeletedResponse,
-}
-
-pub type SaveTextActivityResponse = GraphQLResponse<SaveTextActivityData>;
-pub type SaveMessageActivityResponse = GraphQLResponse<SaveMessageActivityData>;
-pub type DeleteActivityResponse = GraphQLResponse<DeleteActivityData>;
-pub type DeleteReviewResponse = GraphQLResponse<DeleteReviewData>;
-pub type SaveActivityReplyResponse = GraphQLResponse<SaveActivityReplyData>;
-pub type DeleteActivityReplyResponse = GraphQLResponse<DeleteActivityReplyData>;
-
-// MediaList single item response types
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MediaListEntryData {
-    #[serde(rename = "SaveMediaListEntry")]
-    pub save_media_list_entry: MediaList,
-}
-
-// MediaList multiple item response types
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MultipleMediaListEntryData {
-    #[serde(rename = "UpdateMediaListEntries")]
-    pub update_media_list_entries: Vec<MediaList>,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DeleteMediaListData {
-    #[serde(rename = "DeleteMediaListEntry")]
-    pub deleted: bool,
-}
-
-pub type SaveMediaListEntryResponse = GraphQLResponse<MediaListEntryData>;
-pub type SaveMediaListMultipleResponse = GraphQLResponse<MultipleMediaListEntryData>;
-pub type DeleteMediaListEntryResponse = GraphQLResponse<DeleteMediaListData>;
-
-// Common endpoint response types
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ToggleLikeData {
-    #[serde(rename = "ToggleLikeV2")]
-    pub toggle_like_v2: LikeableUnion,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ToggleFollowData {
-    #[serde(rename = "ToggleFollow")]
-    pub toggle_follow: User,
-}
-
-#[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ToggleFavouriteData {
-    #[serde(rename = "ToggleFavourite")]
-    pub toggle_favourite: Favourites,
-}
-
-pub type ToggleLikeResponse = GraphQLResponse<ToggleLikeData>;
-pub type ToggleFollowResponse = GraphQLResponse<ToggleFollowData>;
-pub type ToggleFavouriteResponse = GraphQLResponse<ToggleFavouriteData>;
-
-// Thread/Forum endpoint response types
-pub type ThreadListResponse = GraphQLResponse<Page<ThreadData>>;
-pub type ThreadSingleResponse = GraphQLResponse<ThreadResponse>;
-pub type ThreadCommentListResponse = GraphQLResponse<Page<ThreadCommentData>>;
-pub type ThreadCommentSingleResponse = GraphQLResponse<ThreadCommentResponse>;
-pub type SaveThreadResponse = GraphQLResponse<SaveThreadData>;
-pub type DeleteThreadResponse = GraphQLResponse<DeleteThreadData>;
-pub type SaveThreadCommentResponse = GraphQLResponse<SaveThreadCommentData>;
-pub type DeleteThreadCommentResponse = GraphQLResponse<DeleteThreadCommentData>;
-pub type ToggleThreadSubscriptionResponse = GraphQLResponse<ToggleThreadSubscriptionData>;
 
 // The high-performance custom deserialization logic
 impl<'de, T> Deserialize<'de> for Page<T>

--- a/src/objects/responses.rs
+++ b/src/objects/responses.rs
@@ -1,4 +1,4 @@
-use crate::objects::activity::{ActivityReply, MessageActivity};
+use crate::objects::activity::{ActivityReply, MessageActivity, TextActivity};
 use crate::objects::airing::AiringSchedule;
 use crate::objects::character::Character;
 use crate::objects::common::PageInfo;
@@ -16,11 +16,14 @@ use crate::unions::activity::ActivityUnion;
 use crate::unions::likeable::LikeableUnion;
 use crate::unions::notification::NotificationUnion;
 use serde::{Deserialize, Serialize};
+use serde::de::{self, Deserializer, MapAccess, Visitor};
+use std::fmt;
+use std::marker::PhantomData;
 use serde_with::skip_serializing_none;
 
 /// Top-level GraphQL response wrapper
 #[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphQLResponse<T> {
     pub data: T,
@@ -37,11 +40,10 @@ pub struct PageResponse<T> {
 
 /// Generic page structure
 #[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Page<T> {
-    pub page_info: PageInfo,
-    #[serde(flatten)]
+    pub page_info: Option<PageInfo>,
     pub data: T,
 }
 
@@ -295,30 +297,28 @@ pub struct ViewerUserData {
 }
 
 /// Type aliases for common response patterns
-pub type NotificationResponse = GraphQLResponse<PageResponse<NotificationData>>;
-pub type MediaListResponse = GraphQLResponse<PageResponse<MediaData>>;
-pub type UserMediaListResponse = GraphQLResponse<PageResponse<MediaListData>>;
-pub type CharacterListResponse = GraphQLResponse<PageResponse<CharacterData>>;
-pub type StaffListResponse = GraphQLResponse<PageResponse<StaffData>>;
-pub type StudioListResponse = GraphQLResponse<PageResponse<StudioData>>;
-pub type UserListResponse = GraphQLResponse<PageResponse<UserData>>;
-pub type ActivityListResponse = GraphQLResponse<PageResponse<ActivityData>>;
-pub type ActivityReplyListResponse = GraphQLResponse<PageResponse<ActivityReplyData>>;
-pub type AiringListResponse = GraphQLResponse<PageResponse<AiringData>>;
+pub type NotificationResponse = GraphQLResponse<Page<Vec<NotificationUnion>>>;
+pub type UserMediaListResponse = GraphQLResponse<Page<Vec<MediaList>>>;
+pub type CharacterListResponse = GraphQLResponse<Page<Vec<Character>>>;
+pub type StaffListResponse = GraphQLResponse<Page<Vec<Staff>>>;
+pub type StudioListResponse = GraphQLResponse<Page<Vec<Studio>>>;
+pub type UserListResponse = GraphQLResponse<Page<Vec<User>>>;
+pub type ActivityListResponse = GraphQLResponse<Page<Vec<ActivityUnion>>>;
+pub type ActivityReplyListResponse = GraphQLResponse<Page<Vec<ActivityReply>>>;
+pub type AiringListResponse = GraphQLResponse<Page<Vec<AiringSchedule>>>;
 pub type AiringSingleResponse = GraphQLResponse<AiringScheduleResponse>;
-pub type RecommendationListResponse = GraphQLResponse<PageResponse<RecommendationData>>;
-pub type ReviewListResponse = GraphQLResponse<PageResponse<ReviewData>>;
+pub type RecommendationListResponse = GraphQLResponse<Page<Vec<Recommendation>>>;
+pub type ReviewListResponse = GraphQLResponse<Page<Vec<Review>>>;
 pub type ViewerFinalResponse = GraphQLResponse<ViewerResponse<ViewerUserData>>;
 
 // Single item response types
-pub type MediaSingleResponse = GraphQLResponse<MediaResponse>;
-pub type CharacterSingleResponse = GraphQLResponse<CharacterResponse>;
-pub type StaffSingleResponse = GraphQLResponse<StaffResponse>;
-pub type StudioSingleResponse = GraphQLResponse<StudioResponse>;
-pub type UserSingleResponse = GraphQLResponse<UserResponse>;
-pub type ActivitySingleResponse = GraphQLResponse<ActivityResponse>;
-pub type ReviewSingleResponse = GraphQLResponse<ReviewResponse>;
-pub type RecommendationSingleResponse = GraphQLResponse<RecommendationResponse>;
+pub type CharacterSingleResponse = GraphQLResponse<Character>;
+pub type StaffSingleResponse = GraphQLResponse<Staff>;
+pub type StudioSingleResponse = GraphQLResponse<Studio>;
+pub type UserSingleResponse = GraphQLResponse<User>;
+pub type ActivitySingleResponse = GraphQLResponse<ActivityUnion>;
+pub type ReviewSingleResponse = GraphQLResponse<Review>;
+pub type RecommendationSingleResponse = GraphQLResponse<Recommendation>;
 
 // Activity mutation response types
 #[skip_serializing_none]
@@ -326,7 +326,7 @@ pub type RecommendationSingleResponse = GraphQLResponse<RecommendationResponse>;
 #[serde(rename_all = "camelCase")]
 pub struct SaveTextActivityData {
     #[serde(rename = "SaveTextActivity")]
-    pub save_text_activity: ActivityUnion,
+    pub save_text_activity: TextActivity,
 }
 
 #[skip_serializing_none]
@@ -343,6 +343,15 @@ pub struct SaveMessageActivityData {
 pub struct DeleteActivityData {
     #[serde(rename = "DeleteActivity")]
     pub deleted: DeletedResponse,
+}
+
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteReviewData {
+    #[serde(rename = "DeleteReview")]
+    pub deleted: bool,
 }
 
 #[skip_serializing_none]
@@ -371,6 +380,7 @@ pub struct DeleteActivityReplyData {
 pub type SaveTextActivityResponse = GraphQLResponse<SaveTextActivityData>;
 pub type SaveMessageActivityResponse = GraphQLResponse<SaveMessageActivityData>;
 pub type DeleteActivityResponse = GraphQLResponse<DeleteActivityData>;
+pub type DeleteReviewResponse = GraphQLResponse<DeleteReviewData>;
 pub type SaveActivityReplyResponse = GraphQLResponse<SaveActivityReplyData>;
 pub type DeleteActivityReplyResponse = GraphQLResponse<DeleteActivityReplyData>;
 
@@ -383,6 +393,15 @@ pub struct MediaListEntryData {
     pub save_media_list_entry: MediaList,
 }
 
+// MediaList multiple item response types
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MultipleMediaListEntryData {
+    #[serde(rename = "UpdateMediaListEntries")]
+    pub update_media_list_entries: Vec<MediaList>,
+}
+
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -392,6 +411,7 @@ pub struct DeleteMediaListData {
 }
 
 pub type SaveMediaListEntryResponse = GraphQLResponse<MediaListEntryData>;
+pub type SaveMediaListMultipleResponse = GraphQLResponse<MultipleMediaListEntryData>;
 pub type DeleteMediaListEntryResponse = GraphQLResponse<DeleteMediaListData>;
 
 // Common endpoint response types
@@ -424,12 +444,170 @@ pub type ToggleFollowResponse = GraphQLResponse<ToggleFollowData>;
 pub type ToggleFavouriteResponse = GraphQLResponse<ToggleFavouriteData>;
 
 // Thread/Forum endpoint response types
-pub type ThreadListResponse = GraphQLResponse<PageResponse<ThreadData>>;
+pub type ThreadListResponse = GraphQLResponse<Page<ThreadData>>;
 pub type ThreadSingleResponse = GraphQLResponse<ThreadResponse>;
-pub type ThreadCommentListResponse = GraphQLResponse<PageResponse<ThreadCommentData>>;
+pub type ThreadCommentListResponse = GraphQLResponse<Page<ThreadCommentData>>;
 pub type ThreadCommentSingleResponse = GraphQLResponse<ThreadCommentResponse>;
 pub type SaveThreadResponse = GraphQLResponse<SaveThreadData>;
 pub type DeleteThreadResponse = GraphQLResponse<DeleteThreadData>;
 pub type SaveThreadCommentResponse = GraphQLResponse<SaveThreadCommentData>;
 pub type DeleteThreadCommentResponse = GraphQLResponse<DeleteThreadCommentData>;
 pub type ToggleThreadSubscriptionResponse = GraphQLResponse<ToggleThreadSubscriptionData>;
+
+
+
+
+// The high-performance custom deserialization logic
+impl<'de, T> Deserialize<'de> for Page<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Define a visitor struct to hold the deserialization logic.
+        struct PageVisitor<T>(PhantomData<T>);
+
+        impl<'de, T> Visitor<'de> for PageVisitor<T>
+        where
+            T: Deserialize<'de>,
+        {
+            type Value = Page<T>; // The final type we want to produce
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("an object with a 'pageInfo' field and one other data field")
+            }
+
+            // This method is called by Serde when it encounters a JSON object.
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut page_info = None;
+                let mut data = None;
+
+                // Loop through each key-value pair in the JSON object directly.
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "pageInfo" => {
+                            // Avoid processing the same field twice.
+                            if page_info.is_some() {
+                                return Err(de::Error::duplicate_field("pageInfo"));
+                            }
+                            // Deserialize the value directly into the PageInfo struct.
+                            page_info = Some(map.next_value()?);
+                        }
+                        // Any other key is treated as the data field.
+                        _ => {
+                            if data.is_some() {
+                                return Err(de::Error::custom("found more than one data field"));
+                            }
+                            // Deserialize the value directly into the generic type T.
+                            data = Some(map.next_value()?);
+                        }
+                    }
+                }
+
+                let data = data.ok_or_else(|| de::Error::custom("missing data field"))?;
+
+                // Construct the final Page struct.
+                Ok(Page { page_info, data })
+            }
+        }
+
+        // Instruct Serde to use our custom visitor to deserialize the object.
+        deserializer.deserialize_map(PageVisitor(PhantomData))
+    }
+}
+
+// A private helper struct to represent the inner object: {"any_key": [...]}.
+// It will have its own custom deserialization logic.
+struct InnerData<T> {
+    data: T,
+}
+
+// First, we teach our helper struct how to deserialize itself from an
+// object with a single, dynamically named field.
+impl<'de, T> Deserialize<'de> for InnerData<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct InnerVisitor<T>(PhantomData<T>);
+
+        impl<'de, T> Visitor<'de> for InnerVisitor<T>
+        where
+            T: Deserialize<'de>,
+        {
+            type Value = InnerData<T>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("an object with a single field containing an array")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                // 1. Ignore the key of the single inner field.
+                map.next_key::<de::IgnoredAny>()?
+                    .ok_or_else(|| de::Error::custom("expected a single data field, but the object was empty"))?;
+
+                // 2. Deserialize the value directly into our final T.
+                let data: T = map.next_value()?;
+
+                Ok(InnerData { data })
+            }
+        }
+
+        deserializer.deserialize_map(InnerVisitor(PhantomData))
+    }
+}
+
+// Now, we implement Deserialize for our main GraphQLResponse struct.
+impl<'de, T> Deserialize<'de> for GraphQLResponse<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct OuterVisitor<T>(PhantomData<T>);
+
+        impl<'de, T> Visitor<'de> for OuterVisitor<T>
+        where
+            T: Deserialize<'de>,
+        {
+            type Value = GraphQLResponse<T>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("an object with a single 'data' field")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                // 1. Expect the outer key to be "data".
+                let key = map.next_key::<String>()?
+                    .ok_or_else(|| de::Error::custom("expected field 'data', but object was empty"))?;
+                if key != "data" {
+                    return Err(de::Error::invalid_value(de::Unexpected::Str(&key), &"the field 'data'"));
+                }
+
+                // 2. Deserialize the value using the custom logic we defined for InnerData.
+                let inner: InnerData<T> = map.next_value()?;
+
+                // 3. Construct the final ApiResponse.
+                Ok(GraphQLResponse { data: inner.data })
+            }
+        }
+
+        deserializer.deserialize_map(OuterVisitor(PhantomData))
+    }
+}

--- a/src/objects/thread.rs
+++ b/src/objects/thread.rs
@@ -48,7 +48,6 @@ pub struct ThreadComment {
     pub thread_id: Option<i32>,
     pub comment: Option<String>,
     pub as_html: Option<bool>,
-
     pub like_count: Option<i32>,
     pub is_liked: Option<bool>,
     pub site_url: Option<String>,

--- a/src/queries/media/fetch.graphql
+++ b/src/queries/media/fetch.graphql
@@ -79,6 +79,9 @@ query MediaSearch(
     $sort: [MediaSort]
     $page: Int = 1
     $perPage: Int = 20
+
+    # Extra
+    $description_as_html: Boolean = true
 ) {
     Page(page: $page, perPage: $perPage) {
         pageInfo {
@@ -186,6 +189,8 @@ query MediaSearch(
                 medium
                 color
             }
+            bannerImage
+            description(asHtml: $description_as_html)
             siteUrl
             studios(isMain: true) {
                 edges {

--- a/src/queries/media/fetch.graphql
+++ b/src/queries/media/fetch.graphql
@@ -201,6 +201,12 @@ query MediaSearch(
                     }
                 }
             }
+            mediaListEntry {
+                id
+                status
+                score
+                progress
+            }
         }
     }
 }

--- a/src/queries/media/fetch_one.graphql
+++ b/src/queries/media/fetch_one.graphql
@@ -256,6 +256,31 @@ query (
                 }
             }
         }
+        mediaListEntry {
+            id
+            status
+            score
+            progress
+            progressVolumes
+            repeat
+            priority
+            notes
+            hiddenFromStatusLists
+            customLists
+            advancedScores
+            startedAt {
+                year
+                month
+                day
+            }
+            completedAt {
+                year
+                month
+                day
+            }
+            updatedAt
+            createdAt
+        }
         reviews(page: $reviewsPage, perPage: $reviewsPerPage, sort: RATING_DESC) @include(if: $fetchReviews) {
             pageInfo {
                 total

--- a/src/queries/user/basic.graphql
+++ b/src/queries/user/basic.graphql
@@ -7,9 +7,11 @@ query BasicUserInfo {
         }
         statistics {
             anime {
+                count
                 episodesWatched
             }
             manga {
+                count
                 chaptersRead
             }
         }

--- a/tests/endpoints/activity.rs
+++ b/tests/endpoints/activity.rs
@@ -1,6 +1,6 @@
 //! Tests for Activity endpoint
 
-use anilist_moe::{endpoints::activity::*, unions::activity::ActivityUnion, AniListClient};
+use anilist_moe::{AniListClient, endpoints::activity::*, unions::activity::ActivityUnion};
 use dotenv::dotenv;
 use log::info;
 use std::env;
@@ -298,7 +298,10 @@ async fn test_activity_reply() {
         id: None,
     };
 
-    let fetch_result = client.activity().fetch_replies(&fetch_replies_options).await;
+    let fetch_result = client
+        .activity()
+        .fetch_replies(&fetch_replies_options)
+        .await;
     match fetch_result {
         Ok(response) => {
             info!("Fetch Replies Response: {:?}", response);

--- a/tests/endpoints/activity.rs
+++ b/tests/endpoints/activity.rs
@@ -1,6 +1,6 @@
 //! Tests for Activity endpoint
 
-use anilist_moe::{AniListClient, endpoints::activity::*};
+use anilist_moe::{endpoints::activity::*, unions::activity::ActivityUnion, AniListClient};
 use dotenv::dotenv;
 use log::info;
 use std::env;
@@ -19,7 +19,7 @@ async fn test_fetch_activities() {
         ..Default::default()
     };
 
-    let result = client.activity().fetch(options).await;
+    let result = client.activity().fetch(&options).await;
     if let Err(ref e) = result {
         eprintln!("Error fetching activities: {:?}", e);
     }
@@ -31,7 +31,7 @@ async fn test_fetch_activities() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let activities = &response.data.page.data.activities;
+    let activities = &response.data;
     println!("Fetched {} activities", activities.len());
 }
 
@@ -44,14 +44,14 @@ async fn test_fetch_activities_by_user() {
         ..Default::default()
     };
 
-    let result = client.activity().fetch(options).await;
+    let result = client.activity().fetch(&options).await;
     if let Err(ref e) = result {
         eprintln!("Error fetching activities by user: {:?}", e);
     }
     if result.is_ok() {
         let response = result.unwrap();
         info!("Response: {:?}", response);
-        let activities = &response.data.page.data.activities;
+        let activities = &response.data;
         println!("Fetched {} activities for user", activities.len());
     }
 }
@@ -70,7 +70,7 @@ async fn test_text_activity_full_lifecycle() {
         locked: None,
     };
 
-    let create_result = client.activity().save_text_activity(save_options).await;
+    let create_result = client.activity().save_text_activity(&save_options).await;
     if let Err(ref e) = create_result {
         println!("Failed to create activity: {:?}", e);
         return;
@@ -78,7 +78,7 @@ async fn test_text_activity_full_lifecycle() {
 
     let create_response = create_result.unwrap();
     info!("Create Response: {:?}", create_response);
-    let activity_id = match &create_response.data.save_text_activity {
+    let activity_id = match &create_response {
         anilist_moe::unions::activity::ActivityUnion::TextActivity(a) => {
             println!("✓ Created activity with ID: {}", a.id);
             a.id
@@ -97,7 +97,7 @@ async fn test_text_activity_full_lifecycle() {
         locked: None,
     };
 
-    let modify_result = client.activity().save_text_activity(modify_options).await;
+    let modify_result = client.activity().save_text_activity(&modify_options).await;
     match modify_result {
         Ok(response) => {
             info!("Modify Response: {:?}", response);
@@ -110,11 +110,11 @@ async fn test_text_activity_full_lifecycle() {
     println!("Step 3: Fetching activity...");
     let fetch_options = FetchActivityOneOptions { id: activity_id };
 
-    let fetch_result = client.activity().fetch_one(fetch_options).await;
+    let fetch_result = client.activity().fetch_one(&fetch_options).await;
     match fetch_result {
         Ok(response) => {
             info!("Fetch Response: {:?}", response);
-            match &response.data.activity {
+            match &response {
                 anilist_moe::unions::activity::ActivityUnion::TextActivity(a) => {
                     println!(
                         "✓ Fetched activity: {}",
@@ -131,7 +131,7 @@ async fn test_text_activity_full_lifecycle() {
     println!("Step 4: Deleting activity...");
     let delete_options = DeleteActivityOptions { id: activity_id };
 
-    let delete_result = client.activity().delete(delete_options).await;
+    let delete_result = client.activity().delete(&delete_options).await;
     match delete_result {
         Ok(response) => {
             info!("Delete Response: {:?}", response);
@@ -164,7 +164,7 @@ async fn test_message_activity_full_lifecycle() {
         as_mod: None,
     };
 
-    let create_result = client.activity().save_message_activity(save_options).await;
+    let create_result = client.activity().save_message_activity(&save_options).await;
     if let Err(ref e) = create_result {
         println!("Failed to create message activity: {:?}", e);
         return;
@@ -172,11 +172,12 @@ async fn test_message_activity_full_lifecycle() {
 
     let create_response = create_result.unwrap();
     info!("Create Response: {:?}", create_response);
-    let activity_id = match &create_response.data.save_message_activity {
-        a => {
+    let activity_id = match &create_response {
+        ActivityUnion::MessageActivity(a) => {
             println!("✓ Created message activity with ID: {}", a.id);
             a.id
         }
+        _ => return,
     };
 
     // Step 2: Modify the message activity
@@ -192,7 +193,7 @@ async fn test_message_activity_full_lifecycle() {
 
     let modify_result = client
         .activity()
-        .save_message_activity(modify_options)
+        .save_message_activity(&modify_options)
         .await;
     match modify_result {
         Ok(response) => {
@@ -206,11 +207,11 @@ async fn test_message_activity_full_lifecycle() {
     println!("Step 3: Fetching message activity...");
     let fetch_options = FetchActivityOneOptions { id: activity_id };
 
-    let fetch_result = client.activity().fetch_one(fetch_options).await;
+    let fetch_result = client.activity().fetch_one(&fetch_options).await;
     match fetch_result {
         Ok(response) => {
             info!("Fetch Response: {:?}", response);
-            match &response.data.activity {
+            match &response {
                 anilist_moe::unions::activity::ActivityUnion::MessageActivity(a) => {
                     println!(
                         "✓ Fetched message activity: {}",
@@ -232,7 +233,7 @@ async fn test_message_activity_full_lifecycle() {
     println!("Step 4: Deleting message activity...");
     let delete_options = DeleteActivityOptions { id: activity_id };
 
-    let delete_result = client.activity().delete(delete_options).await;
+    let delete_result = client.activity().delete(&delete_options).await;
     match delete_result {
         Ok(response) => {
             info!("Delete Response: {:?}", response);
@@ -260,7 +261,7 @@ async fn test_activity_reply() {
         id: None,
     };
 
-    let create_result = client.activity().save_reply(save_reply_options).await;
+    let create_result = client.activity().save_reply(&save_reply_options).await;
     if let Err(ref e) = create_result {
         println!("Failed to create reply: {:?}", e);
         return;
@@ -268,7 +269,7 @@ async fn test_activity_reply() {
 
     let create_response = create_result.unwrap();
     info!("Create Reply Response: {:?}", create_response);
-    let reply_id = create_response.data.save_activity_reply.id;
+    let reply_id = create_response.id;
     println!("✓ Created reply with ID: {}", reply_id);
 
     // Step 2: Modify the reply
@@ -279,7 +280,7 @@ async fn test_activity_reply() {
         activity_id,
     };
 
-    let modify_result = client.activity().save_reply(modify_reply_options).await;
+    let modify_result = client.activity().save_reply(&modify_reply_options).await;
     match modify_result {
         Ok(response) => {
             info!("Modify Reply Response: {:?}", response);
@@ -297,11 +298,11 @@ async fn test_activity_reply() {
         id: None,
     };
 
-    let fetch_result = client.activity().fetch_replies(fetch_replies_options).await;
+    let fetch_result = client.activity().fetch_replies(&fetch_replies_options).await;
     match fetch_result {
         Ok(response) => {
             info!("Fetch Replies Response: {:?}", response);
-            let replies = &response.data.page.data.activity_replies;
+            let replies = &response.data;
             let found = replies.iter().find(|r| r.id == reply_id);
             if let Some(reply) = found {
                 println!(
@@ -319,7 +320,7 @@ async fn test_activity_reply() {
     println!("Step 4: Deleting reply...");
     let delete_reply_options = DeleteActivityReplyOptions { id: reply_id };
 
-    let delete_result = client.activity().delete_reply(delete_reply_options).await;
+    let delete_result = client.activity().delete_reply(&delete_reply_options).await;
     match delete_result {
         Ok(response) => {
             info!("Delete Reply Response: {:?}", response);

--- a/tests/endpoints/airing.rs
+++ b/tests/endpoints/airing.rs
@@ -11,7 +11,7 @@ async fn test_fetch_airing_schedules() {
         ..Default::default()
     };
 
-    let result = client.airing().fetch(options).await;
+    let result = client.airing().fetch(&options).await;
     if let Err(ref e) = result {
         eprintln!("Error fetching airing schedules: {:?}", e);
     }
@@ -23,7 +23,7 @@ async fn test_fetch_airing_schedules() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let schedules = &response.data.page.data.airing_schedules;
+    let schedules = &response.data;
     assert!(!schedules.is_empty(), "Should return airing schedules");
 
     let first_schedule = &schedules[0];
@@ -51,7 +51,7 @@ async fn test_fetch_airing_pagination() {
         ..Default::default()
     };
 
-    let result1 = client.airing().fetch(options_page1).await;
+    let result1 = client.airing().fetch(&options_page1).await;
     if let Err(ref e) = result1 {
         eprintln!("Error fetching airing page 1: {:?}", e);
     }
@@ -67,14 +67,14 @@ async fn test_fetch_airing_pagination() {
         ..Default::default()
     };
 
-    let result2 = client.airing().fetch(options_page2).await;
+    let result2 = client.airing().fetch(&options_page2).await;
     assert!(result2.is_ok(), "Should successfully fetch page 2");
 
     let response1 = result1.unwrap();
     let response2 = result2.unwrap();
 
-    let schedules1 = &response1.data.page.data.airing_schedules;
-    let schedules2 = &response2.data.page.data.airing_schedules;
+    let schedules1 = &response1.data;
+    let schedules2 = &response2.data;
 
     let ids1: Vec<Option<i32>> = schedules1.iter().map(|s| s.id).collect();
     let ids2: Vec<Option<i32>> = schedules2.iter().map(|s| s.id).collect();
@@ -89,7 +89,7 @@ async fn test_airing_data_types() {
         ..Default::default()
     };
 
-    let result = client.airing().fetch(options).await;
+    let result = client.airing().fetch(&options).await;
     if let Err(ref e) = result {
         eprintln!("Error fetching airing schedule: {:?}", e);
     }
@@ -101,7 +101,7 @@ async fn test_airing_data_types() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    if let Some(schedule) = response.data.page.data.airing_schedules.first() {
+    if let Some(schedule) = response.data.first() {
         assert!(
             schedule.id.is_some() && schedule.id.unwrap() > 0,
             "ID should be positive"

--- a/tests/endpoints/character.rs
+++ b/tests/endpoints/character.rs
@@ -12,12 +12,12 @@ async fn test_fetch_character_by_search() {
         ..Default::default()
     };
 
-    let result = client.character().fetch(options).await;
+    let result = client.character().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch characters");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let characters = &response.data.page.data.characters;
+    let characters = &response.data;
     assert!(
         !characters.is_empty(),
         "Should return at least one character"
@@ -36,12 +36,12 @@ async fn test_fetch_character_by_id() {
         ..Default::default()
     };
 
-    let result = client.character().fetch(options).await;
+    let result = client.character().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch character by ID");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let characters = &response.data.page.data.characters;
+    let characters = &response.data;
     assert_eq!(characters.len(), 1, "Should return exactly one character");
     assert_eq!(characters[0].id, 1, "Should return correct character ID");
 }
@@ -54,12 +54,12 @@ async fn test_fetch_one_character() {
         ..Default::default()
     };
 
-    let result = client.character().fetch_one(options).await;
+    let result = client.character().fetch_one(&options).await;
     assert!(result.is_ok(), "Should successfully fetch one character");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let character = &response.data.character;
+    let character = &response;
     assert_eq!(character.id, 1, "Should return character with ID 1");
     assert!(character.name.is_some(), "Character should have a name");
 }
@@ -72,12 +72,12 @@ async fn test_character_data_types() {
         ..Default::default()
     };
 
-    let result = client.character().fetch(options).await;
+    let result = client.character().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch character");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let character = &response.data.page.data.characters[0];
+    let character = &response.data[0];
 
     assert!(character.id > 0, "ID should be positive");
 

--- a/tests/endpoints/common.rs
+++ b/tests/endpoints/common.rs
@@ -23,13 +23,13 @@ async fn test_toggle_like() {
         like_type: LikeableType::Activity,
     };
 
-    let result = client.common().toggle_like(options).await;
+    let result = client.common().toggle_like(&options).await;
 
     match result {
         Ok(response) => {
             info!("Response: {:?}", response);
             println!("Successfully toggled like on item");
-            println!("Response data: {:?}", response.data.toggle_like_v2);
+            println!("Response data: {:?}", response);
         }
         Err(e) => {
             println!("Expected authentication error or permission issue: {:?}", e);
@@ -44,7 +44,7 @@ async fn test_toggle_follow() {
     // Try to follow a user
     let options = ToggleFollowOptions { user_id: 5429396 };
 
-    let result = client.common().toggle_follow(options).await;
+    let result = client.common().toggle_follow(&options).await;
 
     match result {
         Ok(response) => {
@@ -52,8 +52,8 @@ async fn test_toggle_follow() {
             println!("Successfully toggled follow");
             println!(
                 "User: {} (ID: {})",
-                response.data.toggle_follow.name.as_ref().unwrap(),
-                response.data.toggle_follow.id
+                response.name.as_ref().unwrap(),
+                response.id
             );
         }
         Err(e) => {
@@ -75,13 +75,13 @@ async fn test_toggle_favourite() {
         studio_id: None,
     };
 
-    let result = client.common().toggle_favourite(options).await;
+    let result = client.common().toggle_favourite(&options).await;
 
     match result {
         Ok(response) => {
             info!("Response: {:?}", response);
             println!("Successfully toggled favourite");
-            println!("Favourites data: {:?}", response.data.toggle_favourite);
+            println!("Favourites data: {:?}", response);
         }
         Err(e) => {
             println!("Expected authentication error or permission issue: {:?}", e);

--- a/tests/endpoints/forum.rs
+++ b/tests/endpoints/forum.rs
@@ -19,7 +19,7 @@ async fn test_fetch_forum_threads() {
         ..Default::default()
     };
 
-    let result = client.forum().fetch(options).await;
+    let result = client.forum().fetch(&options).await;
     if let Err(ref e) = result {
         eprintln!("Error fetching forum threads: {:?}", e);
     }
@@ -32,7 +32,7 @@ async fn test_fetch_forum_threads() {
     let response = result.unwrap();
     info!("Response: {:?}", response);
 
-    let threads = &response.data.page.data.threads;
+    let threads = &response.data;
     assert!(!threads.is_empty(), "Should return at least one thread");
 }
 
@@ -45,13 +45,13 @@ async fn test_fetch_one_forum_thread() {
         per_page: Some(1),
         ..Default::default()
     };
-    let list_result = client.forum().fetch(list_options).await;
+    let list_result = client.forum().fetch(&list_options).await;
     assert!(list_result.is_ok(), "Should successfully fetch threads");
 
     let response = list_result.unwrap();
     info!("Response: {:?}", response);
 
-    let threads = &response.data.page.data.threads;
+    let threads = &response.data;
     if threads.is_empty() {
         println!("No threads found to test fetch_one");
         return;
@@ -65,7 +65,7 @@ async fn test_fetch_one_forum_thread() {
         comments_sort: None,
     };
 
-    let result = client.forum().fetch_one(options).await;
+    let result = client.forum().fetch_one(&options).await;
     if let Err(ref e) = result {
         eprintln!("Error fetching one thread: {:?}", e);
     }
@@ -85,10 +85,10 @@ async fn test_fetch_forum_comments() {
         per_page: Some(1),
         ..Default::default()
     };
-    let list_result = client.forum().fetch(list_options).await;
+    let list_result = client.forum().fetch(&list_options).await;
 
     if let Ok(response) = list_result {
-        let threads = &response.data.page.data.threads;
+        let threads = &response.data;
         if !threads.is_empty() {
             let thread_id = threads[0].id;
             let options = FetchThreadCommentOptions {
@@ -97,7 +97,7 @@ async fn test_fetch_forum_comments() {
                 ..Default::default()
             };
 
-            let result = client.forum().fetch_comments(options).await;
+            let result = client.forum().fetch_comments(&options).await;
             if let Err(ref e) = result {
                 eprintln!("Error fetching forum comments: {:?}", e);
             }
@@ -118,13 +118,13 @@ async fn test_forum_data_types() {
         ..Default::default()
     };
 
-    let result = client.forum().fetch(options).await;
+    let result = client.forum().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch threads");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
 
-    let threads = &response.data.page.data.threads;
+    let threads = &response.data;
     if !threads.is_empty() {
         let thread = &threads[0];
         assert!(thread.id > 0, "Thread ID should be positive");
@@ -150,15 +150,15 @@ async fn test_fetch_comment_one() {
         ..Default::default()
     };
 
-    if let Ok(response) = client.forum().fetch_comments(list_options).await {
-        let comments = &response.data.page.data.thread_comments;
+    if let Ok(response) = client.forum().fetch_comments(&list_options).await {
+        let comments = &response.data;
         if !comments.is_empty() {
             let comment_id = comments[0].id;
             let options = FetchThreadCommentOneOptions {
                 id: Some(comment_id),
             };
 
-            let result = client.forum().fetch_comment_one(options).await;
+            let result = client.forum().fetch_comment_one(&options).await;
             if let Err(ref e) = result {
                 eprintln!("Error fetching one comment: {:?}", e);
             }
@@ -186,12 +186,12 @@ async fn test_save_forum_thread() {
         locked: None,
     };
 
-    let result = client.forum().save(options).await;
+    let result = client.forum().save(&options).await;
 
     match result {
         Ok(response) => {
             println!("Successfully created forum thread");
-            let thread_id = response.data.save_thread.id;
+            let thread_id = response.id;
             println!("Created thread with ID: {}", thread_id);
         }
         Err(e) => {
@@ -210,8 +210,8 @@ async fn test_save_forum_comment() {
         ..Default::default()
     };
 
-    if let Ok(response) = client.forum().fetch(list_options).await {
-        let threads = &response.data.page.data.threads;
+    if let Ok(response) = client.forum().fetch(&list_options).await {
+        let threads = &response.data;
         if !threads.is_empty() {
             let thread_id = threads[0].id;
             let options = SaveThreadCommentOptions {
@@ -222,7 +222,7 @@ async fn test_save_forum_comment() {
                 locked: None,
             };
 
-            let result = client.forum().save_comment(options).await;
+            let result = client.forum().save_comment(&options).await;
 
             match result {
                 Ok(_) => {
@@ -251,11 +251,11 @@ async fn test_delete_forum_thread() {
         locked: None,
     };
 
-    if let Ok(response) = client.forum().save(save_options).await {
-        let thread_id = response.data.save_thread.id;
+    if let Ok(response) = client.forum().save(&save_options).await {
+        let thread_id = response.id;
         let delete_options = DeleteThreadOptions { id: thread_id };
 
-        let result = client.forum().delete(delete_options).await;
+        let result = client.forum().delete(&delete_options).await;
 
         match result {
             Ok(_) => {
@@ -278,8 +278,8 @@ async fn test_delete_forum_comment() {
         ..Default::default()
     };
 
-    if let Ok(response) = client.forum().fetch(list_options).await {
-        let threads = &response.data.page.data.threads;
+    if let Ok(response) = client.forum().fetch(&list_options).await {
+        let threads = &response.data;
         if !threads.is_empty() {
             let thread_id = threads[0].id;
             // Create comment
@@ -291,11 +291,11 @@ async fn test_delete_forum_comment() {
                 locked: None,
             };
 
-            if let Ok(save_response) = client.forum().save_comment(save_options).await {
-                let comment_id = save_response.data.save_thread_comment.id;
+            if let Ok(save_response) = client.forum().save_comment(&save_options).await {
+                let comment_id = save_response.id;
                 let delete_options = DeleteThreadCommentOptions { id: comment_id };
 
-                let result = client.forum().delete_comment(delete_options).await;
+                let result = client.forum().delete_comment(&delete_options).await;
 
                 match result {
                     Ok(_) => {
@@ -320,8 +320,8 @@ async fn test_toggle_thread_subscription() {
         ..Default::default()
     };
 
-    if let Ok(response) = client.forum().fetch(list_options).await {
-        let threads = &response.data.page.data.threads;
+    if let Ok(response) = client.forum().fetch(&list_options).await {
+        let threads = &response.data;
         if !threads.is_empty() {
             let thread_id = threads[0].id;
             let options = ToggleThreadSubscriptionOptions {
@@ -329,7 +329,7 @@ async fn test_toggle_thread_subscription() {
                 subscribe: Some(true),
             };
 
-            let result = client.forum().subscription(options).await;
+            let result = client.forum().subscription(&options).await;
 
             match result {
                 Ok(_) => {
@@ -339,7 +339,7 @@ async fn test_toggle_thread_subscription() {
                         thread_id,
                         subscribe: Some(false),
                     };
-                    let _ = client.forum().subscription(unsub_options).await;
+                    let _ = client.forum().subscription(&unsub_options).await;
                 }
                 Err(e) => {
                     println!("Expected authentication error or permission issue: {:?}", e);

--- a/tests/endpoints/media.rs
+++ b/tests/endpoints/media.rs
@@ -17,15 +17,17 @@ async fn test_fetch_media_with_search() {
         ..Default::default()
     };
 
-    let result = client.media().fetch(options).await;
+    let result = client.media().fetch(&options).await;
+
+    println!("Result: {:?}", result);
 
     assert!(result.is_ok(), "Should successfully fetch media");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    assert!(response.data.page.page_info.current_page.is_some());
+    assert!(response.page_info.as_ref().map(|p| p.current_page).is_some());
 
-    let media_list = &response.data.page.data.media;
+    let media_list = &response.data;
     assert!(
         !media_list.is_empty(),
         "Should return at least one media result"
@@ -48,7 +50,7 @@ async fn test_fetch_media_by_id() {
         ..Default::default()
     };
 
-    let result = client.media().fetch(options).await;
+    let result = client.media().fetch(&options).await;
     if let Err(ref e) = result {
         eprintln!("Error fetching media: {:?}", e);
     }
@@ -60,7 +62,7 @@ async fn test_fetch_media_by_id() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let media_list = &response.data.page.data.media;
+    let media_list = &response.data;
     assert_eq!(media_list.len(), 1, "Should return exactly one media");
 
     let media = &media_list[0];
@@ -76,7 +78,7 @@ async fn test_fetch_one_media() {
         ..Default::default()
     };
 
-    let result = client.media().fetch_one(options).await;
+    let result = client.media().fetch_one(&options).await;
     if let Err(ref e) = result {
         eprintln!("Error fetching one media: {:?}", e);
     }
@@ -88,7 +90,7 @@ async fn test_fetch_one_media() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let media = &response.data.media;
+    let media = &response;
     assert_eq!(media.id, Some(1), "Should return media with ID 1");
     assert!(media.title.is_some(), "Media should have a title");
 }
@@ -101,12 +103,12 @@ async fn test_media_data_types() {
         ..Default::default()
     };
 
-    let result = client.media().fetch(options).await;
+    let result = client.media().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch media");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let media = &response.data.page.data.media[0];
+    let media = &response.data[0];
 
     // Verify ID is required and positive
     assert!(media.id.unwrap_or(0) > 0, "ID should be positive");
@@ -141,7 +143,7 @@ async fn test_fetch_media_pagination() {
         ..Default::default()
     };
 
-    let result1 = client.media().fetch(options_page1).await;
+    let result1 = client.media().fetch(&options_page1).await;
     assert!(result1.is_ok(), "Should successfully fetch page 1");
 
     let options_page2 = FetchMediaOptions {
@@ -152,14 +154,14 @@ async fn test_fetch_media_pagination() {
         ..Default::default()
     };
 
-    let result2 = client.media().fetch(options_page2).await;
+    let result2 = client.media().fetch(&options_page2).await;
     assert!(result2.is_ok(), "Should successfully fetch page 2");
 
     let response1 = result1.unwrap();
     let response2 = result2.unwrap();
 
-    let media_list1 = &response1.data.page.data.media;
-    let media_list2 = &response2.data.page.data.media;
+    let media_list1 = &response1.data;
+    let media_list2 = &response2.data;
 
     assert_eq!(media_list1.len(), 5, "Page 1 should have 5 results");
     assert_eq!(media_list2.len(), 5, "Page 2 should have 5 results");

--- a/tests/endpoints/media.rs
+++ b/tests/endpoints/media.rs
@@ -25,7 +25,13 @@ async fn test_fetch_media_with_search() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    assert!(response.page_info.as_ref().map(|p| p.current_page).is_some());
+    assert!(
+        response
+            .page_info
+            .as_ref()
+            .map(|p| p.current_page)
+            .is_some()
+    );
 
     let media_list = &response.data;
     assert!(

--- a/tests/endpoints/medialist.rs
+++ b/tests/endpoints/medialist.rs
@@ -21,7 +21,7 @@ async fn test_fetch_media_list() {
         ..Default::default()
     };
 
-    let result = client.medialist().fetch(options).await;
+    let result = client.medialist().fetch(&options).await;
     if let Err(ref e) = result {
         eprintln!("Error fetching media list: {:?}", e);
     }
@@ -33,7 +33,7 @@ async fn test_fetch_media_list() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let lists = &response.data.page.data.media_list;
+    let lists = &response.data;
     assert!(
         !lists.is_empty(),
         "Should return at least one media list entry"
@@ -50,7 +50,7 @@ async fn test_fetch_media_list_by_media() {
         ..Default::default()
     };
 
-    let result = client.medialist().fetch(options).await;
+    let result = client.medialist().fetch(&options).await;
     if let Err(ref e) = result {
         eprintln!("Error fetching media list by media: {:?}", e);
     }
@@ -62,7 +62,7 @@ async fn test_fetch_media_list_by_media() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let lists = &response.data.page.data.media_list;
+    let lists = &response.data;
     if !lists.is_empty() {
         let first_entry = &lists[0];
         assert!(
@@ -81,12 +81,12 @@ async fn test_media_list_data_types() {
         ..Default::default()
     };
 
-    let result = client.medialist().fetch(options).await;
+    let result = client.medialist().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch media list");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let lists = &response.data.page.data.media_list;
+    let lists = &response.data;
 
     if !lists.is_empty() {
         let entry = &lists[0];
@@ -108,13 +108,13 @@ async fn test_save_media_list() {
         ..Default::default()
     };
 
-    let result = client.medialist().save(options).await;
+    let result = client.medialist().save(&options).await;
 
     match result {
         Ok(response) => {
             println!(
                 "Successfully saved media list entry with ID: {}",
-                response.data.save_media_list_entry.id
+                response.id
             );
         }
         Err(e) => {
@@ -134,7 +134,7 @@ async fn test_save_multiple_media_lists() {
         ..Default::default()
     };
 
-    let result = client.medialist().save_multiple(options).await;
+    let result = client.medialist().save_multiple(&options).await;
 
     match result {
         Ok(responses) => {
@@ -142,7 +142,7 @@ async fn test_save_multiple_media_lists() {
             for response in responses {
                 println!(
                     "Updated entry ID: {}",
-                    response.data.save_media_list_entry.id
+                    response.id
                 );
             }
         }
@@ -163,19 +163,20 @@ async fn test_delete_media_list() {
         ..Default::default()
     };
 
-    if let Ok(response) = client.medialist().save(save_options).await {
-        let entry_id = response.data.save_media_list_entry.id;
+    if let Ok(response) = client.medialist().save(&save_options).await {
+        let entry_id = response.id;
 
         let delete_options = DeleteMediaListOptions { id: entry_id };
 
-        let result = client.medialist().delete(delete_options).await;
+        let result = client.medialist().delete(&delete_options).await;
 
         match result {
             Ok(response) => {
-                println!(
-                    "Successfully deleted media list entry: {}",
-                    response.data.deleted
-                );
+                if response == true {
+                    println!("Successfully deleted media list entry");
+                } else {
+                    println!("Failed to delete media list entry");
+                }
             }
             Err(e) => {
                 println!("Expected authentication error or permission issue: {:?}", e);

--- a/tests/endpoints/medialist.rs
+++ b/tests/endpoints/medialist.rs
@@ -140,10 +140,7 @@ async fn test_save_multiple_media_lists() {
         Ok(responses) => {
             println!("Successfully saved {} media list entries", responses.len());
             for response in responses {
-                println!(
-                    "Updated entry ID: {}",
-                    response.id
-                );
+                println!("Updated entry ID: {}", response.id);
             }
         }
         Err(e) => {

--- a/tests/endpoints/notification.rs
+++ b/tests/endpoints/notification.rs
@@ -19,14 +19,14 @@ async fn test_fetch_notifications() {
         ..Default::default()
     };
 
-    let result = client.notification().fetch(options).await;
+    let result = client.notification().fetch(&options).await;
 
     // Notifications require authentication
     match result {
         Ok(response) => {
             info!("Response: {:?}", response);
             println!("Successfully fetched notifications");
-            let notifications = &response.data.page.data.notifications;
+            let notifications = &response.data;
             println!("Number of notifications: {}", notifications.len());
         }
         Err(e) => {
@@ -46,11 +46,11 @@ async fn test_notification_data_types() {
         ..Default::default()
     };
 
-    let result = client.notification().fetch(options).await;
+    let result = client.notification().fetch(&options).await;
 
     if let Ok(response) = result {
         println!("Response: {:?}", response);
-        let notifications = &response.data.page.data.notifications;
+        let notifications = &response.data;
         if !notifications.is_empty() {
             let notification_id = match &notifications[0] {
                 anilist_moe::unions::notification::NotificationUnion::Airing(n) => n.id,

--- a/tests/endpoints/recommendation.rs
+++ b/tests/endpoints/recommendation.rs
@@ -19,7 +19,7 @@ async fn test_fetch_recommendations() {
         ..Default::default()
     };
 
-    let result = client.recommendation().fetch(options).await;
+    let result = client.recommendation().fetch(&options).await;
     if let Err(ref e) = result {
         eprintln!("Error fetching recommendations: {:?}", e);
     }
@@ -31,7 +31,7 @@ async fn test_fetch_recommendations() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let recommendations = &response.data.page.data.recommendations;
+    let recommendations = &response.data;
     assert!(
         !recommendations.is_empty(),
         "Should return at least one recommendation"
@@ -47,7 +47,7 @@ async fn test_fetch_recommendations_by_media() {
         ..Default::default()
     };
 
-    let result = client.recommendation().fetch(options).await;
+    let result = client.recommendation().fetch(&options).await;
     assert!(
         result.is_ok(),
         "Should successfully fetch recommendations by media"
@@ -55,7 +55,7 @@ async fn test_fetch_recommendations_by_media() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let recommendations = &response.data.page.data.recommendations;
+    let recommendations = &response.data;
     if !recommendations.is_empty() {
         let first_rec = &recommendations[0];
         assert!(first_rec.id > 0, "Recommendation should have a positive ID");
@@ -70,12 +70,12 @@ async fn test_recommendation_data_types() {
         ..Default::default()
     };
 
-    let result = client.recommendation().fetch(options).await;
+    let result = client.recommendation().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch recommendations");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let recommendations = &response.data.page.data.recommendations;
+    let recommendations = &response.data;
 
     if !recommendations.is_empty() {
         let rec = &recommendations[0];
@@ -97,16 +97,13 @@ async fn test_save_recommendation() {
         rating: 1, // 1 = upvote, -1 = downvote
     };
 
-    let result = client.recommendation().save(options).await;
+    let result = client.recommendation().save(&options).await;
 
     match result {
         Ok(response) => {
             info!("Save Response: {:?}", response);
             println!("Successfully saved recommendation");
-            let recs = &response.data.page.data.recommendations;
-            if let Some(rec) = recs.first() {
-                println!("Recommendation ID: {}", rec.id);
-            }
+            println!("Recommendation ID: {}", response.id);
         }
         Err(e) => {
             println!("Expected authentication error or permission issue: {:?}", e);

--- a/tests/endpoints/review.rs
+++ b/tests/endpoints/review.rs
@@ -99,10 +99,7 @@ async fn test_save_review() {
     match result {
         Ok(response) => {
             info!("Save Response: {:?}", response);
-            println!(
-                "Successfully saved review with ID: {}",
-                response.id
-            );
+            println!("Successfully saved review with ID: {}", response.id);
         }
         Err(e) => {
             println!("Expected authentication error or permission issue: {:?}", e);

--- a/tests/endpoints/review.rs
+++ b/tests/endpoints/review.rs
@@ -19,7 +19,7 @@ async fn test_fetch_reviews() {
         ..Default::default()
     };
 
-    let result = client.review().fetch(options).await;
+    let result = client.review().fetch(&options).await;
     if let Err(ref e) = result {
         eprintln!("Error fetching reviews: {:?}", e);
     }
@@ -31,7 +31,7 @@ async fn test_fetch_reviews() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let reviews = &response.data.page.data.reviews;
+    let reviews = &response.data;
     assert!(!reviews.is_empty(), "Should return at least one review");
 }
 
@@ -44,12 +44,12 @@ async fn test_fetch_reviews_by_media() {
         ..Default::default()
     };
 
-    let result = client.review().fetch(options).await;
+    let result = client.review().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch reviews by media");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let reviews = &response.data.page.data.reviews;
+    let reviews = &response.data;
     if !reviews.is_empty() {
         let first_review = &reviews[0];
         assert!(first_review.id > 0, "Review should have a positive ID");
@@ -64,12 +64,12 @@ async fn test_review_data_types() {
         ..Default::default()
     };
 
-    let result = client.review().fetch(options).await;
+    let result = client.review().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch reviews");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let reviews = &response.data.page.data.reviews;
+    let reviews = &response.data;
 
     if !reviews.is_empty() {
         let review = &reviews[0];
@@ -94,14 +94,14 @@ async fn test_save_review() {
         id: None,
     };
 
-    let result = client.review().save(options).await;
+    let result = client.review().save(&options).await;
 
     match result {
         Ok(response) => {
             info!("Save Response: {:?}", response);
             println!(
                 "Successfully saved review with ID: {}",
-                response.data.review.id
+                response.id
             );
         }
         Err(e) => {
@@ -120,8 +120,8 @@ async fn test_rate_review() {
         ..Default::default()
     };
 
-    if let Ok(response) = client.review().fetch(fetch_options).await {
-        let reviews = &response.data.page.data.reviews;
+    if let Ok(response) = client.review().fetch(&fetch_options).await {
+        let reviews = &response.data;
         if !reviews.is_empty() {
             let review_id = reviews[0].id;
 
@@ -130,7 +130,7 @@ async fn test_rate_review() {
                 rating: 1, // 1 = upvote, 0 = no vote, -1 = downvote
             };
 
-            let result = client.review().rate(rate_options).await;
+            let result = client.review().rate(&rate_options).await;
 
             match result {
                 Ok(_) => {
@@ -140,7 +140,7 @@ async fn test_rate_review() {
                         review_id,
                         rating: 0,
                     };
-                    let _ = client.review().rate(reset_options).await;
+                    let _ = client.review().rate(&reset_options).await;
                 }
                 Err(e) => {
                     println!("Expected authentication error or permission issue: {:?}", e);
@@ -164,12 +164,12 @@ async fn test_delete_review() {
         id: None,
     };
 
-    if let Ok(response) = client.review().save(save_options).await {
-        let review_id = response.data.review.id;
+    if let Ok(response) = client.review().save(&save_options).await {
+        let review_id = response.id;
 
         let delete_options = DeleteReviewOptions { id: review_id };
 
-        let result = client.review().delete(delete_options).await;
+        let result = client.review().delete(&delete_options).await;
 
         match result {
             Ok(_) => {

--- a/tests/endpoints/staff.rs
+++ b/tests/endpoints/staff.rs
@@ -11,12 +11,12 @@ async fn test_fetch_staff_by_search() {
         ..Default::default()
     };
 
-    let result = client.staff().fetch(options).await;
+    let result = client.staff().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch staff");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let staff_list = &response.data.page.data.staff;
+    let staff_list = &response.data;
     assert!(
         !staff_list.is_empty(),
         "Should return at least one staff member"
@@ -35,12 +35,12 @@ async fn test_fetch_staff_by_id() {
         ..Default::default()
     };
 
-    let result = client.staff().fetch(options).await;
+    let result = client.staff().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch staff by ID");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let staff_list = &response.data.page.data.staff;
+    let staff_list = &response.data;
     assert_eq!(
         staff_list.len(),
         1,
@@ -57,12 +57,12 @@ async fn test_fetch_one_staff() {
         ..Default::default()
     };
 
-    let result = client.staff().fetch_one(options).await;
+    let result = client.staff().fetch_one(&options).await;
     assert!(result.is_ok(), "Should successfully fetch one staff");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let staff = &response.data.staff;
+    let staff = &response;
     assert_eq!(staff.id, 95269, "Should return correct staff ID");
 }
 
@@ -74,12 +74,12 @@ async fn test_staff_data_types() {
         ..Default::default()
     };
 
-    let result = client.staff().fetch(options).await;
+    let result = client.staff().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch staff");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let staff = &response.data.page.data.staff[0];
+    let staff = &response.data[0];
 
     assert!(staff.id > 0, "ID should be positive");
 

--- a/tests/endpoints/studio.rs
+++ b/tests/endpoints/studio.rs
@@ -12,12 +12,12 @@ async fn test_fetch_studio_by_search() {
         ..Default::default()
     };
 
-    let result = client.studio().fetch(options).await;
+    let result = client.studio().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch studios");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let studios = &response.data.page.data.studios;
+    let studios = &response.data;
     assert!(!studios.is_empty(), "Should return at least one studio");
 
     let first_studio = &studios[0];
@@ -36,12 +36,12 @@ async fn test_fetch_studio_by_id() {
         ..Default::default()
     };
 
-    let result = client.studio().fetch(options).await;
+    let result = client.studio().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch studio by ID");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let studios = &response.data.page.data.studios;
+    let studios = &response.data;
     assert_eq!(studios.len(), 1, "Should return exactly one studio");
     assert_eq!(studios[0].id, Some(2), "Should return correct studio ID");
 }
@@ -54,7 +54,7 @@ async fn test_fetch_one_studio() {
         ..Default::default()
     };
 
-    let result = client.studio().fetch_one(options).await;
+    let result = client.studio().fetch_one(&options).await;
     if let Err(ref e) = result {
         eprintln!("Error fetching one studio: {:?}", e);
     }
@@ -66,7 +66,7 @@ async fn test_fetch_one_studio() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let studio = &response.data.studio;
+    let studio = &response;
     assert_eq!(studio.id, Some(2), "Should return studio with ID 2");
 }
 
@@ -78,12 +78,12 @@ async fn test_studio_data_types() {
         ..Default::default()
     };
 
-    let result = client.studio().fetch(options).await;
+    let result = client.studio().fetch(&options).await;
     assert!(result.is_ok(), "Should successfully fetch studio");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let studio = &response.data.page.data.studios[0];
+    let studio = &response.data[0];
 
     if let Some(id) = studio.id {
         assert!(id > 0, "ID should be positive");

--- a/tests/endpoints/user.rs
+++ b/tests/endpoints/user.rs
@@ -24,7 +24,7 @@ async fn test_fetch_user_by_search() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let users = &response.data.page.data.users;
+    let users = &response.data;
     assert!(!users.is_empty(), "Should return at least one user");
 
     let first_user = &users[0];
@@ -48,7 +48,7 @@ async fn test_fetch_user_by_id() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let users = &response.data.page.data.users;
+    let users = &response.data;
     assert_eq!(users.len(), 1, "Should return exactly one user");
 }
 
@@ -60,12 +60,12 @@ async fn test_fetch_one_user() {
         ..Default::default()
     };
 
-    let result = client.user().fetch_one(options).await;
+    let result = client.user().fetch_one(&options).await;
     assert!(result.is_ok(), "Should successfully fetch one user");
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let user = &response.data.user;
+    let user = &response;
     assert!(user.id > 0, "User should have positive ID");
     assert!(
         !user.name.as_ref().unwrap().is_empty(),
@@ -86,7 +86,7 @@ async fn test_user_data_types() {
 
     let response = result.unwrap();
     info!("Response: {:?}", response);
-    let user = &response.data.page.data.users[0];
+    let user = &response.data[0];
 
     assert!(
         !user.name.as_ref().unwrap().is_empty(),


### PR DESCRIPTION
# Update to V3

## [0.3.0] - 2024-10-14

### Changed
- **Response Format Simplification**: Major refactoring of response types for cleaner API
  - Removed redundant wrapper types (`PageResponse`, `ViewerResponse`, etc.)
  - Simplified response access patterns: `response.data` instead of nested wrappers
  - All endpoints now use `GraphQLResponse<T>` and `Page<T>` directly
  - Example: `GraphQLResponse<Page<Vec<Media>>>` instead of `GraphQLResponse<PageResponse<MediaData>>`
- **Common Endpoint**: Simplified return types
  - `toggle_like()` now returns `LikeableUnion` directly instead of `ToggleLikeResponse`
  - `toggle_follow()` now returns `User` directly instead of `ToggleFollowResponse`
  - `toggle_favourite()` now returns `Favourites` directly instead of `ToggleFavouriteResponse`
- **Review Endpoint**: Simplified delete operation
  - `delete()` now returns `bool` directly
  - Uses `Deleted` struct internally for consistency
- **User Endpoint**: Fixed authenticated user fetch
  - `fetch_basic()` now returns `User` directly instead of `ViewerUserData`
  - Simplified viewer query responses

### Fixed
- **MediaExternalLink**: Made all fields public for proper access (#4 by @Nachtalb, fixed #3)
  - Fields `id`, `url`, `site`, `type`, `language`, `color`, `icon`, and `isDisabled` are now public
- **ListActivity**: Made `status` field public for proper access
- **MediaConnection**: Made `edges`, `nodes`, and `page_info` fields public
- **MediaEdge**: Made `node`, `id`, and `relation_type` fields public
- **ThreadComment**: Removed extra blank line for code consistency

### Breaking Changes
- Response structure changed from `response.data.page.data.media` to `response.data` for paginated endpoints
- Response wrapper types removed - direct access to data types
- All endpoints return simplified response types